### PR TITLE
YAML files are streams

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -295,7 +295,7 @@
 
       <ul>
         <li>YAML supports different encodings, including UTF-8, UTF-16, and UTF-32.</li>
-        <li>YAML supports more data types than JSON.</li>
+        <li>YAML supports more native data types than JSON.</li>
         <li>the structure of a YAML document &mdash; that is, a named YAML representation graph &mdash;
         is a rooted, directed graph that can have cycles.</li>
         <li>YAML has the concept of stream, which is a sequence of documents.

--- a/spec/index.html
+++ b/spec/index.html
@@ -221,7 +221,7 @@
         to represent information serialized as JSON,
         including Linked Data.
         This document defines how to serialize linked data
-        in YAML documents.
+        in YAML.
         Moreover, it registers the application/ld+yaml media type.
       </p>
     </section>
@@ -244,15 +244,12 @@
         Since YAML is more expressive than JSON,
         both in the available data types and in the document structure
         (see [[I-D.ietf-httpapi-yaml-mediatypes]]),
-        this document identifies constraints on YAML documents
-        such that they can be used to represent JSON-LD documents.
+        this document identifies constraints on YAML
+        such that it can be used to represent JSON-LD documents.
       </p>
     </section>
 
   <section id="conformance">
-    <p>A <a>YAML-LD document</a> complies with this specification if ...</p>
-    <p class="ednote">Define <dfn>YAML-LD document</dfn> somewhere.</p>
-
     <p>This specification makes use of the following namespace prefixes:</p>
     <table class="simple">
       <thead><tr>
@@ -301,6 +298,11 @@
         <li>YAML supports more data types than JSON.</li>
         <li>the structure of a YAML document &mdash; that is, a named YAML representation graph &mdash;
         is a rooted, directed graph that can have cycles.</li>
+        <li>YAML has the concept of stream, which is a sequence of documents.
+            While a stream usually contains one document,
+            streams with multiple documents are used to aggregate multiple,
+            related, documents into a single file or network stream.
+        </li>
 
     <p>
       The first goal of this specification is to allow a JSON-LD document to be
@@ -353,14 +355,22 @@
     <h2>Core Requirements</h2>
 
     <p>
-      A YAML-LD document is a [[YAML]] document that can be interpreted as Linked Data [[LINKED-DATA]].
+      A YAML-LD stream is a YAML stream of YAML-LD documents.
+      Note that each document in a stream is independent
+      from the others:
+      each one has its own context, YAML directives,
+      named anchors and so on.
+    </p>
+    <p>
+      A YAML-LD document is a [[YAML]] document
+      that can be interpreted as Linked Data [[LINKED-DATA]].
     </p>
     <p>
       It MUST be encoded in UTF-8, to ensure interoperability with [[JSON]]. 
     </p>
     <p>
       Comments in YAML-LD documents
-      are treated as white space
+      are treated as white space.
       This behavior is consistent with other
       Linked Data serializations like [[TURTLE]].
       See Interoperability considerations of [[I-D.ietf-httpapi-yaml-mediatypes]]
@@ -381,7 +391,7 @@
     </p>
     <p data-format="markdown">
       Example: The following YAML-LD document
-      contains alias nodes for the `{"@id": "country:ITA"}` object:
+      contains alias nodes for the `{"@id": "countries:ITA"}` object:
 
       ```yaml
       %YAML 1.2

--- a/spec/index.html
+++ b/spec/index.html
@@ -587,7 +587,7 @@
 
     #### Why does YAML-LD not preserve comments?
     <p class="ednote">
-    [[JSON]] (and hence [[JSON-LD]]) does not support comments,
+    [[JSON]] (and hence [[JSON-LD11]]) does not support comments,
     and other Linked Data serialization formats
     that support comments (such as [[TURTLE]])
     do not provide a means to preserve them


### PR DESCRIPTION
## This PR

- clarify that files are streams
- streams can contain one or more documents
- the specification is related to documents and reflects on streams.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/49.html" title="Last updated on Jul 5, 2022, 7:15 PM UTC (9c192e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/49/1d2ffe5...9c192e5.html" title="Last updated on Jul 5, 2022, 7:15 PM UTC (9c192e5)">Diff</a>