### PR TITLE
Fix example: no escaping, only quote

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -378,7 +378,7 @@
     <p>
       Can be serialized as YAML as follows.
       Note that entries
-      starting with  `@` need to be enclosed in quotes or escaped because
+      starting with  `@` need to be enclosed in quotes because
       `@` is a reserved character in YAML.
     </p>
 
@@ -389,13 +389,13 @@
       <!--
       %YAML 1.2
       ---
-      "@context": http://example.org/context.jsonld
-      \@graph:
+      '@context': http://example.org/context.jsonld
+      '@graph':
         -
-          "@id": http://example.org/1
+          '@id': http://example.org/1
           title: Example 1
         -
-          \@id: http://example.org/2
+          '@id': http://example.org/2
           title: Example 2
         -
           '@id': http://example.org/3


### PR DESCRIPTION
## This PR

Fixes example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/56.html" title="Last updated on Jul 10, 2022, 3:17 PM UTC (b5cd5d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/56/567fda6...b5cd5d2.html" title="Last updated on Jul 10, 2022, 3:17 PM UTC (b5cd5d2)">Diff</a>