### PR TITLE
Update YAML reference to 1.2.2, addressing references to "YAML stream".

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -297,6 +297,8 @@
         Each document in a stream has its own context, [[YAML]] directives, named anchors, and so on.
     </p>
 
+    <p class="note"><a>YAML streams</a> were introduced in YAML 1.2.2, and cannot be used in earlier versions.</p>
+    
     <p>A <dfn>YAML-LD document</dfn> is any <a>YAML document</a> from
       which a conversion to [[JSON]] produces
       a valid <a>JSON-LD document</a> which can be interpreted as [[LINKED-DATA]].
@@ -420,6 +422,7 @@
           While a stream often contains one document,
           streams with multiple documents are used to aggregate multiple,
           related, documents into a single file or network stream.
+          <div class="note"><a>YAML streams</a> were introduced in YAML 1.2.2, and cannot be used in earlier versions.</div>
       </li>
     </ul>
 
@@ -625,6 +628,9 @@
       Each of the individual <a>YAML documents</a> in the stream has to be converted into a <a>JSON-LD document</a> and
       processed separately.
     </p>
+
+    <p class="note">YAML streams were introduced in YAML 1.2.2, and cannot be used in earlier versions.</p>
+
   </section>
 
   <section id="sec" class="informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -54,6 +54,7 @@
       "YAML": {
         title: "YAML Ain’t Markup Language (YAML™) version 1.2.2",
         href: "https://yaml.org/spec/1.2.2/",
+        date: "2021-10-01",
         authors: [
           "Oren Ben-Kiki",
           "Clark Evans",

--- a/spec/index.html
+++ b/spec/index.html
@@ -50,6 +50,16 @@
           "Philippe Le Hegaret",
         ],
       },
+
+      "YAML": {
+        title: "YAML Ain’t Markup Language (YAML™) version 1.2.2",
+        href: "https://yaml.org/spec/1.2.2/",
+        authors: [
+          "Oren Ben-Kiki",
+          "Clark Evans",
+          "Ingy döt Net"
+        ]
+      }
     },
 
     // Cross-reference definitions
@@ -322,7 +332,6 @@
       <dfn data-cite="YAML#3211-nodes" data-no-xref="">node</dfn>,
       <dfn data-cite="YAML#3211-nodes" data-no-xref="">scalar</dfn>,
       <dfn data-cite="YAML#3222-anchors-and-aliases" data-no-xref="">named anchor</dfn>,
-      <span class="ednote">(should this be <a data-cite="YAML#named-handles" data-no-xref="">named handle</a>?)</span>
       and <dfn data-cite="YAML#71-alias-nodes" data-no-xref="">alias node</dfn>,
       are imported from [[YAML]].</p>
 


### PR DESCRIPTION
Note that the title was changed to "YAML Ain’t Markup Language (YAML™) version 1.2.2" from "YAML Ain’t Markup Language (YAML™) version 1.2". Arguably, we should be using `[[YAML122]]` to be more explicit, and should probably note something about 1.2.2 being the minimum version supported.

Fixes #61.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/64.html" title="Last updated on Jul 26, 2022, 7:53 PM UTC (e01af8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/64/78a329e...e01af8f.html" title="Last updated on Jul 26, 2022, 7:53 PM UTC (e01af8f)">Diff</a>