### PR TITLE
Mapping keys must be strings (PR #6 for issue #94)

### DIFF
--- a/spec/data/json-vs-yaml.yaml
+++ b/spec/data/json-vs-yaml.yaml
@@ -124,3 +124,9 @@ $reverse:
       yaml:
         prov:value: yes
         prov:wasDerivedFrom: YAML#3222-anchors-and-aliases
+
+    - rdfs:label: Mapping key types
+      json: string
+      yaml:
+        prov:value: Any type representable in YAML, from strings to mappings
+        prov:wasDerivedFrom: YAML#3211-nodes

--- a/spec/data/spec.yaml
+++ b/spec/data/spec.yaml
@@ -55,8 +55,8 @@ $included:
           - rdfs:label: YAML features supported by YAML-LD
           - rdfs:label: Encoding
           - rdfs:label: Comments
-          - rdfs:label: Anchors and aliases
-          - rdfs:label: Streams
+          - rdfs:label: Anchors and Aliases
+          - rdfs:label: Mapping Key Types
 
       - rdfs:label: Security Considerations
       - rdfs:label: Interoperability Considerations

--- a/spec/index.html
+++ b/spec/index.html
@@ -685,6 +685,14 @@
           <td>❌</td>
           <td><a data-cite="YAML#3222-anchors-and-aliases">✅</a></td>
         </tr>
+
+        <tr>
+          <th>Mapping key types</th>
+          <td><code>string</code></td>
+          <td>
+            <a data-cite="YAML#3211-nodes">Any type representable in YAML</a>, from strings to mappings
+          </td>
+        </tr>
         </tbody>
       </table>
 
@@ -789,6 +797,9 @@
 
         <dt>YAML Streams</dt>
         <dd>Not supported.</dd>
+
+        <dt>Mapping key types other than <code>string</code></dt>
+        <dd><a href="#mapping-key-types">Not supported.</a></dd>
       </dl>
 
       <p>
@@ -824,7 +835,7 @@
     </section>
 
     <section id="anchors-aliases">
-    <h2>Anchors and aliases</h2>
+    <h2>Anchors and Aliases</h2>
     <p id="aa-information" data-tests="">
       Since <a>anchor names</a> are a serialization detail, such anchors
       MUST NOT be used to convey relevant information,
@@ -932,6 +943,14 @@
         }
       -->
     </pre>
+    </section>
+
+    <section id="mapping-key-types">
+      <h2>Mapping Key Types</h2>
+
+      <p id="aa-mapping-key-types" data-tests="basic-manifest.html#cir-mapping-key-1-negative">
+        Mapping key type MUST be a <code>string</code>. Otherwise, a processing error is raised.
+      </p>
     </section>
   </section>
 


### PR DESCRIPTION
# YAML can even use mappings as mapping keys

JSON does not support that, and JSON-LD data model doesn't understand it as well. This is not supported by current YAML-LD.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/113.html" title="Last updated on Aug 17, 2023, 8:01 AM UTC (85fa5a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/113/fc592d6...85fa5a7.html" title="Last updated on Aug 17, 2023, 8:01 AM UTC (85fa5a7)">Diff</a>