### PR TITLE
A few `basic` tests failing

### DIFF
--- a/tests/basic/cir-scalar-other-1-positive-out.yamlld
+++ b/tests/basic/cir-scalar-other-1-positive-out.yamlld
@@ -7,6 +7,8 @@
   - "@value": 123.45
   http://example.com/ystring:
   - "@value": string
+  http://example.com/ynull:
+  - "@value": null
   http://example.com/ybool:
   - "@value": true
   http://example.com/integer:

--- a/tests/basic/cir-scalar-other-1-positive-out.yamlld
+++ b/tests/basic/cir-scalar-other-1-positive-out.yamlld
@@ -7,8 +7,6 @@
   - "@value": 123.45
   http://example.com/ystring:
   - "@value": string
-  http://example.com/ynull:
-  - "@value": null
   http://example.com/ybool:
   - "@value": true
   http://example.com/integer:

--- a/tests/basic/cr-comments-1-positive-in.yamlld
+++ b/tests/basic/cr-comments-1-positive-in.yamlld
@@ -6,7 +6,7 @@
 "@id": http://example.org/test#example
 "@type": t1
 notacomment:
-  - this is#not: a comment
+  - this-is#not: a comment
   -  |
     --- >
     line1

--- a/tests/basic/cr-comments-1-positive-out.yamlld
+++ b/tests/basic/cr-comments-1-positive-out.yamlld
@@ -3,7 +3,7 @@
   "@type":
   - http://example.com/t1
   http://example.com/notacomment:
-  - {}  # That is what we get from `this is#not: a comment`. This behavior is confirmed by JSON-LD playground.
+  - http://example.com/this-is#not: a comment
   - "@value": |
       --- >
       line1

--- a/tests/basic/cr-comments-1-positive-out.yamlld
+++ b/tests/basic/cr-comments-1-positive-out.yamlld
@@ -3,8 +3,7 @@
   "@type":
   - http://example.com/t1
   http://example.com/notacomment:
-  - http://example.com/this is#not:
-    - "@value": a comment
+  - {}  # That is what we get from `this is#not: a comment`. This behavior is confirmed by JSON-LD playground.
   - "@value": |
       --- >
       line1


### PR DESCRIPTION
# Comments test

Expand operation converts a mapping with a # in key to an empty object. Try this out in the playground:

```json
{
  "@context": {
    "@vocab": "http://example.com/"
  },
  "@id": "http://example.org/test#example",
  "@type": "t1",
  "notacomment": [
    {"this is#not": "a comment"}
  ]
}
```