### PR TITLE
Test updates for duplicates and differences with extendedYAML interpretation

### DIFF
--- a/tests/cases/cir-scalar-other-2-positive-out.nq
+++ b/tests/cases/cir-scalar-other-2-positive-out.nq
@@ -3,9 +3,9 @@ _:b0 <http://example.com/yfloat> "1.2345E2"^^<http://www.w3.org/2001/XMLSchema#d
 _:b0 <http://example.com/ystring> "string" .
 _:b0 <http://example.com/ybool> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
 _:b0 <http://example.com/integer> "123"^^<http://www.w3.org/2001/XMLSchema#integer> .
-_:b0 <http://example.com/decimal> "123.456"^^<http://www.w3.org/2001/XMLSchema#decimal> .
-_:b0 <http://example.com/double> "123.456e78"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:b0 <http://example.com/decimal> "1.23456E2"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:b0 <http://example.com/double> "123.456e78" .
 _:b0 <http://example.com/bool> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
-_:b0 <http://example.com/date> "2022-08-08"^^<http://www.w3.org/2001/XMLSchema#date> .
-_:b0 <http://example.com/time> "12:00:00.000"^^<http://www.w3.org/2001/XMLSchema#time> .
-_:b0 <http://example.com/dateTime> "2022-08-08T12:00:00.000"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+_:b0 <http://example.com/date> "2022-08-08" .
+_:b0 <http://example.com/time> "12:00:00.000" .
+_:b0 <http://example.com/dateTime> "2022-08-08T12:00:00.000" .

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -260,13 +260,13 @@
               </dd>
 
               <dt id="cir-scalar-i18n-1-positive">
-                Test cir-scalar-i18n-1-positive language-tagged string with i18n
+                Test cir-scalar-i18n-1-positive language-tagged string with i18n (ignored without extendedYAML)
               </dt>
               <dd>
                 <dl class="entry">
                   <dt>ID</dt><dd>#cir-scalar-i18n-1-positive</dd></dt>
                   <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
-                  <dt>Name</dt><dd>language-tagged string with i18n</dd></dt>
+                  <dt>Name</dt><dd>language-tagged string with i18n (ignored without extendedYAML)</dd></dt>
                   <dt>Purpose</dt><dd>Otherwise, the conversion result is mapped through the YAML Core Schema.</dd></dt>
                   <dt>Input</dt><dd><a href="cases/cir-scalar-i18n-1-positive-in.yamlld">cases/cir-scalar-i18n-1-positive-in.yamlld</a></dd></dt>
                   <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-json">1</a>)</dd></dt>
@@ -275,18 +275,21 @@
                   
                   <dt>Expect</dt><dd><a href="cases/cir-scalar-i18n-1-positive-out.yamlld">cases/cir-scalar-i18n-1-positive-out.yamlld</a></dd>
                   
-                  
+                  <dt>Options</dt>
+                    <dd><dl class="options">
+                    <dt>extendedYAML</dt><dd>false</dd>
+                    </dl></dd>
                 </dl>
               </dd>
 
               <dt id="cir-scalar-other-1-positive">
-                Test cir-scalar-other-1-positive Scalars with other node tags
+                Test cir-scalar-other-1-positive Scalars with other node tags (ignored without extendedYAML)
               </dt>
               <dd>
                 <dl class="entry">
                   <dt>ID</dt><dd>#cir-scalar-other-1-positive</dd></dt>
                   <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
-                  <dt>Name</dt><dd>Scalars with other node tags</dd></dt>
+                  <dt>Name</dt><dd>Scalars with other node tags (ignored without extendedYAML)</dd></dt>
                   <dt>Purpose</dt><dd>Otherwise, the conversion result is mapped through the YAML Core Schema.</dd></dt>
                   <dt>Input</dt><dd><a href="cases/cir-scalar-other-1-positive-in.yamlld">cases/cir-scalar-other-1-positive-in.yamlld</a></dd></dt>
                   <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-other">1</a>) (<a href="../spec/index.html#cir-scalar-json">2</a>)</dd></dt>
@@ -295,7 +298,10 @@
                   
                   <dt>Expect</dt><dd><a href="cases/cir-scalar-other-1-positive-out.yamlld">cases/cir-scalar-other-1-positive-out.yamlld</a></dd>
                   
-                  
+                  <dt>Options</dt>
+                    <dd><dl class="options">
+                    <dt>extendedYAML</dt><dd>false</dd>
+                    </dl></dd>
                 </dl>
               </dd>
 
@@ -459,26 +465,6 @@
                 </dl>
               </dd>
 
-              <dt id="cir-scalar-core-1-positive">
-                Test cir-scalar-core-1-positive tag:yaml.org.2002 scalars
-              </dt>
-              <dd>
-                <dl class="entry">
-                  <dt>ID</dt><dd>#cir-scalar-core-1-positive</dd></dt>
-                  <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
-                  <dt>Name</dt><dd>tag:yaml.org.2002 scalars</dd></dt>
-                  <dt>Purpose</dt><dd>If t resolves with a prefix of <code>tag:yaml.org.2002:</code>, the conversion result is mapped through the YAML Core Schema.</dd></dt>
-                  <dt>Input</dt><dd><a href="cases/cir-scalar-core-1-positive-in.yamlld">cases/cir-scalar-core-1-positive-in.yamlld</a></dd></dt>
-                  <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-core">1</a>) (<a href="../spec/index.html#cir-scalar-json">2</a>)</dd></dt>
-                  <dt>Requirement</dt><dd><strong>must</strong></dd>
-                  
-                  
-                  <dt>Expect</dt><dd><a href="cases/cir-scalar-core-1-positive-out.yamlld">cases/cir-scalar-core-1-positive-out.yamlld</a></dd>
-                  
-                  
-                </dl>
-              </dd>
-
               <dt id="cir-scalar-core-2-positive">
                 Test cir-scalar-core-2-positive tag:yaml.org.2002 scalars (RDF)
               </dt>
@@ -499,63 +485,26 @@
                 </dl>
               </dd>
 
-              <dt id="cir-scalar-i18n-1-positive">
-                Test cir-scalar-i18n-1-positive language-tagged string with i18n
-              </dt>
-              <dd>
-                <dl class="entry">
-                  <dt>ID</dt><dd>#cir-scalar-i18n-1-positive</dd></dt>
-                  <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
-                  <dt>Name</dt><dd>language-tagged string with i18n</dd></dt>
-                  <dt>Purpose</dt><dd>If t resolves with a prefix of <code>https://www.w3.org/ns/i18n#</code>, and the suffix <strong>does not</strong> contain an underscore, the conversion result is a language-tagged string.</dd></dt>
-                  <dt>Input</dt><dd><a href="cases/cir-scalar-i18n-1-positive-in.yamlld">cases/cir-scalar-i18n-1-positive-in.yamlld</a></dd></dt>
-                  <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-json">1</a>)</dd></dt>
-                  <dt>Requirement</dt><dd><strong>must</strong></dd>
-                  
-                  
-                  <dt>Expect</dt><dd><a href="cases/cir-scalar-i18n-1-positive-out.yamlld">cases/cir-scalar-i18n-1-positive-out.yamlld</a></dd>
-                  
-                  
-                </dl>
-              </dd>
-
-              <dt id="cir-scalar-other-1-positive">
-                Test cir-scalar-other-1-positive Scalars with other node tags
-              </dt>
-              <dd>
-                <dl class="entry">
-                  <dt>ID</dt><dd>#cir-scalar-other-1-positive</dd></dt>
-                  <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
-                  <dt>Name</dt><dd>Scalars with other node tags</dd></dt>
-                  <dt>Purpose</dt><dd>Otherwise, the conversion result is an RDF literal.</dd></dt>
-                  <dt>Input</dt><dd><a href="cases/cir-scalar-other-1-positive-in.yamlld">cases/cir-scalar-other-1-positive-in.yamlld</a></dd></dt>
-                  <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-other">1</a>) (<a href="../spec/index.html#cir-scalar-json">2</a>)</dd></dt>
-                  <dt>Requirement</dt><dd><strong>must</strong></dd>
-                  
-                  
-                  <dt>Expect</dt><dd><a href="cases/cir-scalar-other-1-positive-out.yamlld">cases/cir-scalar-other-1-positive-out.yamlld</a></dd>
-                  
-                  
-                </dl>
-              </dd>
-
               <dt id="cir-scalar-other-2-positive">
-                Test cir-scalar-other-2-positive Scalars with other node tags (RDF)
+                Test cir-scalar-other-2-positive Scalars with other node tags (RDF)  (ignored without extendedYAML)
               </dt>
               <dd>
                 <dl class="entry">
                   <dt>ID</dt><dd>#cir-scalar-other-2-positive</dd></dt>
                   <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ToRDFTest</dd>
-                  <dt>Name</dt><dd>Scalars with other node tags (RDF)</dd></dt>
+                  <dt>Name</dt><dd>Scalars with other node tags (RDF)  (ignored without extendedYAML)</dd></dt>
                   <dt>Purpose</dt><dd>Otherwise, the conversion result is an RDF literal.</dd></dt>
                   <dt>Input</dt><dd><a href="cases/cir-scalar-other-2-positive-in.yamlld">cases/cir-scalar-other-2-positive-in.yamlld</a></dd></dt>
                   <dt>References</dt><dd>(<a href="../spec/index.html#cir-scalar-other">1</a>)</dd></dt>
-                  <dt>Requirement</dt><dd><strong>must</strong></dd>
+                  <dt>Requirement</dt><dd><strong>may</strong></dd>
                   
                   
                   <dt>Expect</dt><dd><a href="cases/cir-scalar-other-2-positive-out.nq">cases/cir-scalar-other-2-positive-out.nq</a></dd>
                   
-                  
+                  <dt>Options</dt>
+                    <dd><dl class="options">
+                    <dt>extendedYAML</dt><dd>false</dd>
+                    </dl></dd>
                 </dl>
               </dd>
 

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -72,18 +72,20 @@
     {
       "@id": "#cir-scalar-i18n-1-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "language-tagged string with i18n",
+      "name": "language-tagged string with i18n (ignored without extendedYAML)",
       "purpose": "Otherwise, the conversion result is mapped through the YAML Core Schema.",
       "req": "must",
+      "option": {"extendedYAML": false},
       "input": "cases/cir-scalar-i18n-1-positive-in.yamlld",
       "expect": "cases/cir-scalar-i18n-1-positive-out.yamlld"
     },
     {
       "@id": "#cir-scalar-other-1-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Scalars with other node tags",
+      "name": "Scalars with other node tags (ignored without extendedYAML)",
       "purpose": "Otherwise, the conversion result is mapped through the YAML Core Schema.",
       "req": "must",
+      "option": {"extendedYAML": false},
       "input": "cases/cir-scalar-other-1-positive-in.yamlld",
       "expect": "cases/cir-scalar-other-1-positive-out.yamlld"
     },
@@ -160,15 +162,6 @@
       "expect": "cases/aa-cycles-3-positive-out.yamlld"
     },
     {
-      "@id": "#cir-scalar-core-1-positive",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "tag:yaml.org.2002 scalars",
-      "purpose": "If t resolves with a prefix of `tag:yaml.org.2002:`, the conversion result is mapped through the YAML Core Schema.",
-      "req": "must",
-      "input": "cases/cir-scalar-core-1-positive-in.yamlld",
-      "expect": "cases/cir-scalar-core-1-positive-out.yamlld"
-    },
-    {
       "@id": "#cir-scalar-core-2-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "tag:yaml.org.2002 scalars (RDF)",
@@ -178,29 +171,12 @@
       "expect": "cases/cir-scalar-core-2-positive-out.nq"
     },
     {
-      "@id": "#cir-scalar-i18n-1-positive",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "language-tagged string with i18n",
-      "purpose": "If t resolves with a prefix of `https://www.w3.org/ns/i18n#`, and the suffix <strong>does not</strong> contain an underscore, the conversion result is a language-tagged string.",
-      "req": "must",
-      "input": "cases/cir-scalar-i18n-1-positive-in.yamlld",
-      "expect": "cases/cir-scalar-i18n-1-positive-out.yamlld"
-    },
-    {
-      "@id": "#cir-scalar-other-1-positive",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Scalars with other node tags",
-      "purpose": "Otherwise, the conversion result is an RDF literal.",
-      "req": "must",
-      "input": "cases/cir-scalar-other-1-positive-in.yamlld",
-      "expect": "cases/cir-scalar-other-1-positive-out.yamlld"
-    },
-    {
       "@id": "#cir-scalar-other-2-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Scalars with other node tags (RDF)",
+      "name": "Scalars with other node tags (RDF) - extended YAML-LD",
       "purpose": "Otherwise, the conversion result is an RDF literal.",
-      "req": "must",
+      "req": "may",
+      "option": {"extendedYAML": true},
       "input": "cases/cir-scalar-other-2-positive-in.yamlld",
       "expect": "cases/cir-scalar-other-2-positive-out.nq"
     },

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -173,10 +173,10 @@
     {
       "@id": "#cir-scalar-other-2-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "Scalars with other node tags (RDF) - extended YAML-LD",
+      "name": "Scalars with other node tags (RDF)  (ignored without extendedYAML)",
       "purpose": "Otherwise, the conversion result is an RDF literal.",
       "req": "may",
-      "option": {"extendedYAML": true},
+      "option": {"extendedYAML": false},
       "input": "cases/cir-scalar-other-2-positive-in.yamlld",
       "expect": "cases/cir-scalar-other-2-positive-out.nq"
     },


### PR DESCRIPTION
* Set extendedYAML: false option on cir-scalar-i18n-1 and cir-scalar-other-1 tests as results differ.
* Mark tests requiring extended YAML-LD as "may" (cir-scalar-other-* and cir-scalar-i18n).
* Remove duplicate test entries.

Note that if extendedYAML is used, the first two tests yield different results. cir-scalar-other-2 has test results consistent with extendedYAML, so "reg" is changed to "may" and the `extendedYAML` option is added back.