### PR TITLE
Final Report snapshot.

### DIFF
--- a/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
+++ b/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
@@ -1,0 +1,3830 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+<meta name="generator" content="ReSpec 34.2.2">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+:is(aside,div).example{border-left-width:.5em;border-left-style:solid;border-color:#e0cb52;background:#fcfaee}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+.example pre{background-color:rgba(0,0,0,.03)}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+pre.idl{padding:1em;position:relative}
+pre.idl>code{color:#000}
+@media print{
+pre.idl{white-space:pre-wrap}
+}
+.idlHeader{display:block;width:150px;background:#8ccbf2;color:#fff;font-family:sans-serif;font-weight:700;margin:-1em 0 1em -1em;height:28px;line-height:28px}
+.idlHeader a.self-link{margin-left:.3cm;text-decoration:none;border-bottom:none}
+.idlID{font-weight:700;color:#005a9c}
+.idlType{color:#005a9c}
+.idlName{color:#ff4500}
+.idlName a{color:#ff4500;border-bottom:1px dotted #ff4500;text-decoration:none}
+a.idlEnumItem{color:#000;border-bottom:1px dotted #ccc;text-decoration:none}
+.idlSuperclass{font-style:italic;color:#005a9c}
+.idlDefaultValue,.idlParamName{font-style:italic}
+.extAttr{color:#666}
+.idlSectionComment{color:gray}
+.idlIncludes a{font-weight:700}
+.respec-button-copy-paste:focus{text-decoration:none;border-color:#51a7e8;outline:0;box-shadow:0 0 5px rgba(81,167,232,.5)}
+.respec-button-copy-paste:is(:focus:hover,.selected:focus){border-color:#51a7e8}
+.respec-button-copy-paste:is(:hover,:active,.zeroclipboard-is-hover,.zeroclipboard-is-active){text-decoration:none;background-color:#ddd;background-image:linear-gradient(#eee,#ddd);border-color:#ccc}
+.respec-button-copy-paste:is(:active,.selected,.zeroclipboard-is-active){background-color:#dcdcdc;background-image:none;border-color:#b5b5b5;box-shadow:inset 0 2px 4px rgba(0,0,0,.15)}
+.respec-button-copy-paste.selected:hover{background-color:#cfcfcf}
+.respec-button-copy-paste:is(:disabled,:disabled:hover,.disabled,.disabled:hover){color:rgba(102,102,102,.5);cursor:default;background-color:rgba(229,229,229,.5);background-image:none;border-color:rgba(197,197,197,.5);box-shadow:none}
+@media print{
+.respec-button-copy-paste{visibility:hidden}
+}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;color:#000;box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;margin-top:.25em}
+.dfn-panel ul a[href]{color:#333}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+
+<title>YAML-LD</title>
+
+
+
+
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    // Add example button selection logic
+    for (const button of document.querySelectorAll(".ds-selector-tabs .selectors button")) {
+      button.onclick = () => {
+        const ex = button.closest(".ds-selector-tabs");
+        ex.querySelector("button.selected").classList.remove("selected");
+        ex.querySelector(".selected").classList.remove("selected");
+        button.classList.add('selected');
+        ex.querySelector("." + button.dataset.selects).classList.add("selected");
+      }
+    }
+
+    // Toggle show/hide changes
+    for (const elem of document.querySelectorAll(".show-changes")) {
+      elem.onclick = () => {
+        if (elem.classList.contains("selected")) {
+          // Remove highlight class from elements having "changed" class
+          elem.classList.remove("selected");
+          for (const changed of document.querySelectorAll(".changed")) {
+            changed.classList.remove("highlight");
+          }
+        } else {
+          // Add highlight class to elements having "changed" class
+          elem.classList.add("selected");
+          for (const changed of document.querySelectorAll(".changed")) {
+            changed.classList.add("highlight");
+          }
+        }
+      }
+    }
+  });
+</script>
+
+<style>
+
+  .hidden { display: none;}
+  .hl-bold { font-weight: bold; color: #0a3; }
+  .comment { color: #999; }
+  table, thead, tr, td { padding: 5px; border-width: 1px; border-spacing: 0px; border-style: solid; border-collapse: collapse; }
+  table.example {width: 100%;}
+  .example > pre.context:before {
+    content: "Context";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.frame:before {
+    content: "Frame";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.input:before {
+    content: "Input";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.result:before {
+    content: "Result";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.flattened:before {
+    content: "Flattened";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.expanded:before {
+    content: "Expanded";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  .example > pre.turtle:before {
+    content: "Turtle";
+    float: right;
+    font: x-large Arial, sans-serif;
+    color: gray;
+    border: solid thin black;
+    padding: 0.2em;
+  }
+  aside.example {
+    overflow-y: hidden;
+  }
+  /* example tab selection */
+  .ds-selector-tabs {
+    padding-bottom: 2em;
+  }
+  .ds-selector-tabs .selectors {
+    padding: 0;
+    border-bottom: 1px solid #ccc;
+    height: 28px;
+  }
+  .ds-selector-tabs .selectors button {
+    display: inline-block;
+    min-width: 54px;
+    text-align: center;
+    font-size: 11px;
+    font-weight: bold;
+    height: 27px;
+    padding: 0 8px;
+    line-height: 27px;
+    transition: all,0.218s;
+    border-top-right-radius: 2px;
+    border-top-left-radius: 2px;
+    color: #666;
+    border: 1px solid transparent;
+  }
+  .ds-selector-tabs .selectors button:first-child {
+    margin-left: 2px;
+  }
+  .ds-selector-tabs .selectors button.selected {
+    color: #202020 !important;
+    border: 1px solid #ccc;
+    border-bottom: 1px solid #fff !important;
+  }
+  .ds-selector-tabs .selectors button:hover {
+    background-color: transparent;
+    color: #202020;
+    cursor: pointer;
+  }
+  .ds-selector-tabs pre:not(.preserve), .ds-selector-tabs table:not(.preserve) {
+    display: none;
+  }
+  .ds-selector-tabs pre.selected, .ds-selector-tabs table.selected {
+    display: block;
+  }
+  a.playground {
+    display: inline-block;
+    width: 150px;
+    border: 1px solid transparent;
+    border-top-right-radius: 2px;
+    border-top-left-radius: 2px;
+    background-color: rgb(192, 192, 192);
+    text-decoration: none;
+    font-size: 13px;
+    margin-bottom: 10px;
+  }
+  a[href].playground {
+    padding: 4px 0 3px 8px;
+    border-bottom: none;
+    text-decoration: none;
+    color: #666;
+  }
+  .algorithm ol {
+    counter-reset: numsection;
+    list-style-type: none;
+  }
+  .algorithm ol>li {
+    margin: 0.5em 0;
+  }
+  .algorithm ol>li:before {
+    font-weight: bold;
+    counter-increment: numsection;
+    content: counters(numsection, ".") ") ";
+  }
+  code {
+    color:#c63501
+  }  
+
+</style>
+
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+:is(h1,h2,h3,h4,h5,h6,a) abbr{border:none}
+dfn{font-weight:700}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+.toc a,.tof a{text-decoration:none}
+a .figno,a .secno{color:#000}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}
+.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}
+.simple th a{color:#fff;padding:3px 5px;text-align:left}
+.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}
+.simple td{padding:3px 10px;border-top:1px solid #ddd}
+.simple tr:nth-child(even){background:#f0f6ff}
+.section dd>p:first-child{margin-top:0}
+.section dd>p:last-child{margin-bottom:0}
+.section dd{margin-bottom:1em}
+.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+<meta name="description" content="Objective
+      This document defines YAML-LD, a set of conventions built on top
+      of YAML, which outlines how to serialize Linked Data as YAML
+      based on JSON-LD syntax, semantics, and APIs. The emergence of
+      YAML as a more concise format for representing information
+      previously serialized as JSON, including Linked Data, has led to
+      the development of YAML-LD.">
+<link rel="canonical" href="https://www.w3.org/community/reports/json-ld/yaml-ld/">
+<script type="application/ld+json">{
+  "@context": [
+    "http://schema.org",
+    {
+      "@vocab": "http://schema.org/",
+      "@language": "en",
+      "w3p": "http://www.w3.org/2001/02pd/rec54#",
+      "foaf": "http://xmlns.com/foaf/0.1/",
+      "datePublished": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date"
+      },
+      "inLanguage": {
+        "@language": null
+      },
+      "isBasedOn": {
+        "@type": "@id"
+      },
+      "license": {
+        "@type": "@id"
+      }
+    }
+  ],
+  "id": "https://www.w3.org/community/reports/json-ld/yaml-ld/",
+  "type": [
+    "TechArticle"
+  ],
+  "name": "YAML-LD",
+  "inLanguage": "en",
+  "license": "https://www.w3.org/copyright/software-license-2023/",
+  "datePublished": "2023-12-06",
+  "copyrightHolder": {
+    "name": "World Wide Web Consortium",
+    "url": "https://www.w3.org/"
+  },
+  "discussionUrl": "https://github.com/json-ld/yaml-ld/issues/",
+  "alternativeHeadline": "",
+  "isBasedOn": "",
+  "description": "Objective\n      This document defines YAML-LD, a set of conventions built on top\n      of YAML, which outlines how to serialize Linked Data as YAML\n      based on JSON-LD syntax, semantics, and APIs. The emergence of\n      YAML as a more concise format for representing information\n      previously serialized as JSON, including Linked Data, has led to\n      the development of YAML-LD.",
+  "editor": [
+    {
+      "type": "Person",
+      "name": "JSON-LD Community"
+    }
+  ],
+  "contributor": [],
+  "citation": [
+    {
+      "id": "https://www.w3.org/TR/json-ld11/",
+      "type": "TechArticle",
+      "name": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
+      "creator": [
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Pierre-Antoine Champin"
+        },
+        {
+          "name": "Dave Longley"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://yaml.org/spec/1.2.2/",
+      "type": "TechArticle",
+      "name": "YAML Ain’t Markup Language (YAML™) version 1.2.2",
+      "url": "https://yaml.org/spec/1.2.2/",
+      "creator": [
+        {
+          "name": "Oren Ben-Kiki"
+        },
+        {
+          "name": "Clark Evans"
+        },
+        {
+          "name": "Ingy döt Net"
+        }
+      ]
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8259",
+      "type": "TechArticle",
+      "name": "The JavaScript Object Notation (JSON) Data Interchange Format",
+      "url": "https://www.rfc-editor.org/rfc/rfc8259",
+      "creator": [
+        {
+          "name": "T. Bray, Ed."
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/DesignIssues/LinkedData.html",
+      "type": "TechArticle",
+      "name": "Linked Data Design Issues",
+      "url": "https://www.w3.org/DesignIssues/LinkedData.html",
+      "creator": [
+        {
+          "name": "Tim Berners-Lee"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html",
+      "type": "TechArticle",
+      "name": "YAML Media Type",
+      "url": "https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html",
+      "creator": [
+        {
+          "name": "Roberto Polli"
+        },
+        {
+          "name": "Erik Wilde"
+        },
+        {
+          "name": "Eemeli Aro"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc6838",
+      "type": "TechArticle",
+      "name": "Media Type Specifications and Registration Procedures",
+      "url": "https://www.rfc-editor.org/rfc/rfc6838",
+      "creator": [
+        {
+          "name": "N. Freed"
+        },
+        {
+          "name": "J. Klensin"
+        },
+        {
+          "name": "T. Hansen"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc6906",
+      "type": "TechArticle",
+      "name": "The 'profile' Link Relation Type",
+      "url": "https://www.rfc-editor.org/rfc/rfc6906",
+      "creator": [
+        {
+          "name": "E. Wilde"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc4288",
+      "type": "TechArticle",
+      "name": "Media Type Specifications and Registration Procedures",
+      "url": "https://www.rfc-editor.org/rfc/rfc4288",
+      "creator": [
+        {
+          "name": "N. Freed"
+        },
+        {
+          "name": "J. Klensin"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://httpwg.org/specs/rfc9110.html",
+      "type": "TechArticle",
+      "name": "HTTP Semantics",
+      "url": "https://httpwg.org/specs/rfc9110.html",
+      "creator": [
+        {
+          "name": "R. Fielding, Ed."
+        },
+        {
+          "name": "M. Nottingham, Ed."
+        },
+        {
+          "name": "J. Reschke, Ed."
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc3987",
+      "type": "TechArticle",
+      "name": "Internationalized Resource Identifiers (IRIs)",
+      "url": "https://www.rfc-editor.org/rfc/rfc3987",
+      "creator": [
+        {
+          "name": "M. Duerst"
+        },
+        {
+          "name": "M. Suignard"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc2119",
+      "type": "TechArticle",
+      "name": "Key words for use in RFCs to Indicate Requirement Levels",
+      "url": "https://www.rfc-editor.org/rfc/rfc2119",
+      "creator": [
+        {
+          "name": "S. Bradner"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8174",
+      "type": "TechArticle",
+      "name": "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words",
+      "url": "https://www.rfc-editor.org/rfc/rfc8174",
+      "creator": [
+        {
+          "name": "B. Leiba"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/json-ld11-api/",
+      "type": "TechArticle",
+      "name": "JSON-LD 1.1 Processing Algorithms and API",
+      "url": "https://www.w3.org/TR/json-ld11-api/",
+      "creator": [
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Dave Longley"
+        },
+        {
+          "name": "Pierre-Antoine Champin"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc3986",
+      "type": "TechArticle",
+      "name": "Uniform Resource Identifier (URI): Generic Syntax",
+      "url": "https://www.rfc-editor.org/rfc/rfc3986",
+      "creator": [
+        {
+          "name": "T. Berners-Lee"
+        },
+        {
+          "name": "R. Fielding"
+        },
+        {
+          "name": "L. Masinter"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://infra.spec.whatwg.org/",
+      "type": "TechArticle",
+      "name": "Infra Standard",
+      "url": "https://infra.spec.whatwg.org/",
+      "creator": [
+        {
+          "name": "Anne van Kesteren"
+        },
+        {
+          "name": "Domenic Denicola"
+        }
+      ],
+      "publisher": {
+        "name": "WHATWG"
+      }
+    },
+    {
+      "id": "https://tc39.es/ecma262/multipage/",
+      "type": "TechArticle",
+      "name": "ECMAScript Language Specification",
+      "url": "https://tc39.es/ecma262/multipage/",
+      "publisher": {
+        "name": "Ecma International"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/rdf11-concepts/",
+      "type": "TechArticle",
+      "name": "RDF 1.1 Concepts and Abstract Syntax",
+      "url": "https://www.w3.org/TR/rdf11-concepts/",
+      "creator": [
+        {
+          "name": "Richard Cyganiak"
+        },
+        {
+          "name": "David Wood"
+        },
+        {
+          "name": "Markus Lanthaler"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc3986",
+      "type": "TechArticle",
+      "name": "Uniform Resource Identifier (URI): Generic Syntax",
+      "url": "https://www.rfc-editor.org/rfc/rfc3986",
+      "creator": [
+        {
+          "name": "T. Berners-Lee"
+        },
+        {
+          "name": "R. Fielding"
+        },
+        {
+          "name": "L. Masinter"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://w3c.github.io/json-ld-bp/",
+      "type": "TechArticle",
+      "name": "JSON-LD Best Practices",
+      "url": "https://w3c.github.io/json-ld-bp/",
+      "creator": [
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Ivan Herman"
+        },
+        {
+          "name": "BigBlueHat"
+        },
+        {
+          "name": "A. Soroka"
+        },
+        {
+          "name": "Ruben Taelman"
+        },
+        {
+          "name": "David I. Lehn"
+        },
+        {
+          "name": "Philippe Le Hegaret"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/turtle/",
+      "type": "TechArticle",
+      "name": "RDF 1.1 Turtle",
+      "url": "https://www.w3.org/TR/turtle/",
+      "creator": [
+        {
+          "name": "Eric Prud'hommeaux"
+        },
+        {
+          "name": "Gavin Carothers"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/rdf-schema/",
+      "type": "TechArticle",
+      "name": "RDF Schema 1.1",
+      "url": "https://www.w3.org/TR/rdf-schema/",
+      "creator": [
+        {
+          "name": "Dan Brickley"
+        },
+        {
+          "name": "Ramanathan Guha"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/owl2-syntax/",
+      "type": "TechArticle",
+      "name": "OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)",
+      "url": "https://www.w3.org/TR/owl2-syntax/",
+      "creator": [
+        {
+          "name": "Boris Motik"
+        },
+        {
+          "name": "Peter Patel-Schneider"
+        },
+        {
+          "name": "Bijan Parsia"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/json-ld/",
+      "type": "TechArticle",
+      "name": "JSON-LD 1.0",
+      "url": "https://www.w3.org/TR/json-ld/",
+      "creator": [
+        {
+          "name": "Manu Sporny"
+        },
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Markus Lanthaler"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/json-ld11-framing/",
+      "type": "TechArticle",
+      "name": "JSON-LD 1.1 Framing",
+      "url": "https://www.w3.org/TR/json-ld11-framing/",
+      "creator": [
+        {
+          "name": "Dave Longley"
+        },
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Pierre-Antoine Champin"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc6839",
+      "type": "TechArticle",
+      "name": "Additional Media Type Structured Syntax Suffixes",
+      "url": "https://www.rfc-editor.org/rfc/rfc6839",
+      "creator": [
+        {
+          "name": "T. Hansen"
+        },
+        {
+          "name": "A. Melnikov"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7464",
+      "type": "TechArticle",
+      "name": "JavaScript Object Notation (JSON) Text Sequences",
+      "url": "https://www.rfc-editor.org/rfc/rfc7464",
+      "creator": [
+        {
+          "name": "N. Williams"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/xmlschema11-2/",
+      "type": "TechArticle",
+      "name": "W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes",
+      "url": "https://www.w3.org/TR/xmlschema11-2/",
+      "creator": [
+        {
+          "name": "David Peterson"
+        },
+        {
+          "name": "Sandy Gao"
+        },
+        {
+          "name": "Ashok Malhotra"
+        },
+        {
+          "name": "Michael Sperberg-McQueen"
+        },
+        {
+          "name": "Henry Thompson"
+        },
+        {
+          "name": "Paul V. Biron"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc2045",
+      "type": "TechArticle",
+      "name": "Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies",
+      "url": "https://www.rfc-editor.org/rfc/rfc2045",
+      "creator": [
+        {
+          "name": "N. Freed"
+        },
+        {
+          "name": "N. Borenstein"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    }
+  ]
+}</script>
+<style>
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;background:#fafafa}
+.hljs-comment,.hljs-quote{color:#717277;font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;font-weight:700}
+.hljs-literal{color:#0b76c5}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "specStatus": "CG-FINAL",
+  "copyrightStart": "2020",
+  "shortName": "yaml-ld",
+  "edDraftURI": "https://json-ld.github.io/yaml-ld/",
+  "latestVersion": "https://www.w3.org/community/reports/json-ld/yaml-ld/",
+  "github": {
+    "repoURL": "https://github.com/json-ld/yaml-ld/",
+    "branch": "main"
+  },
+  "doJsonLd": true,
+  "editors": [
+    {
+      "name": "JSON-LD Community"
+    }
+  ],
+  "localBiblio": {
+    "I-D.ietf-httpapi-yaml-mediatypes": {
+      "title": "YAML Media Type",
+      "href": "https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html",
+      "publisher": "IETF",
+      "date": "2022-08-05",
+      "status": "WG Document",
+      "authors": [
+        "Roberto Polli",
+        "Erik Wilde",
+        "Eemeli Aro"
+      ],
+      "id": "i-d.ietf-httpapi-yaml-mediatypes"
+    },
+    "json-ld-bp": {
+      "title": "JSON-LD Best Practices",
+      "href": "https://w3c.github.io/json-ld-bp/",
+      "publisher": "W3C",
+      "date": "2022-05-24",
+      "status": "W3C Group Note",
+      "authors": [
+        "Gregg Kellogg",
+        "Ivan Herman",
+        "BigBlueHat",
+        "A. Soroka",
+        "Ruben Taelman",
+        "David I. Lehn",
+        "Philippe Le Hegaret"
+      ],
+      "id": "json-ld-bp"
+    },
+    "YAML": {
+      "title": "YAML Ain’t Markup Language (YAML™) version 1.2.2",
+      "href": "https://yaml.org/spec/1.2.2/",
+      "date": "2021-10-01",
+      "authors": [
+        "Oren Ben-Kiki",
+        "Clark Evans",
+        "Ingy döt Net"
+      ],
+      "id": "yaml"
+    }
+  },
+  "xref": [
+    "json-ld11",
+    "json-ld11-api"
+  ],
+  "testSuiteURI": "https://json-ld.github.io/yaml-ld/tests/",
+  "postProcess": [
+    null
+  ],
+  "group": "cg/json-ld",
+  "wgPublicList": "public-linked-json",
+  "maxTocLevel": 4,
+  "publishDate": "2023-12-06",
+  "publishISODate": "2023-12-06T00:00:00.000Z",
+  "generatedSubtitle": "Final Community Group Report 06 December 2023"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-final"></head>
+<body class="h-entry" data-cite="WEBIDL json-ld11 json-ld11-api"><div class="head">
+    
+    <h1 id="title" class="title">YAML-LD</h1> 
+    <p id="w3c-state">
+      <a href="https://www.w3.org/standards/types#reports">Final Community Group Report</a>
+      <time class="dt-published" datetime="2023-12-06">06 December 2023</time>
+    </p>
+    <dl>
+      <dt>This version:</dt><dd>
+              <a class="u-url" href="https://www.w3.org/community/reports/cg/json-ld/CG-FINAL-yaml-ld-20231206/">https://www.w3.org/community/reports/cg/json-ld/CG-FINAL-yaml-ld-20231206/</a>
+            </dd>
+      <dt>Latest published version:</dt><dd>
+              <a href="https://www.w3.org/community/reports/json-ld/yaml-ld/">https://www.w3.org/community/reports/json-ld/yaml-ld/</a>
+            </dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://json-ld.github.io/yaml-ld/">https://json-ld.github.io/yaml-ld/</a></dd>
+      <dt>Test suite:</dt><dd><a href="https://json-ld.github.io/yaml-ld/tests/">https://json-ld.github.io/yaml-ld/tests/</a></dd>
+      
+      
+      
+      <dt>Editor:</dt><dd class="editor p-author h-card vcard">
+    <span class="p-name fn">JSON-LD Community</span>
+  </dd>
+      
+      
+      <dt>Feedback:</dt><dd>
+        <a href="https://github.com/json-ld/yaml-ld/">GitHub json-ld/yaml-ld</a>
+        (<a href="https://github.com/json-ld/yaml-ld/pulls/">pull requests</a>,
+        <a href="https://github.com/json-ld/yaml-ld/issues/new/choose">new issue</a>,
+        <a href="https://github.com/json-ld/yaml-ld/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-linked-json@w3.org?subject=%5Byaml-ld%5D%20YOUR%20TOPIC%20HERE">public-linked-json@w3.org</a> with subject line <kbd>[yaml-ld] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-linked-json">archives</a>)</dd>
+      
+    </dl>
+    
+    <p class="copyright">
+          <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+          ©
+          2020-2023
+          
+          the Contributors to the YAML-LD
+          Specification, published by the
+          <a href="https://www.w3.org/groups/cg/json-ld">JSON for Linking Data Community Group</a> under the
+          <a href="https://www.w3.org/community/about/agreements/fsa/">W3C Community Final Specification Agreement (FSA)</a>. A human-readable
+                <a href="https://www.w3.org/community/about/agreements/fsa-deed/">summary</a>
+                is available.
+              
+        </p>
+    <hr title="Separator for header">
+  </div>
+  <section id="abstract" class="introductory"><h2>Abstract</h2>
+    <p>
+      <strong>Objective</strong><br>
+      This document defines YAML-LD, a set of conventions built on top
+      of YAML, which outlines how to serialize Linked Data as YAML
+      based on JSON-LD syntax, semantics, and APIs. The emergence of
+      YAML as a more concise format for representing information
+      previously serialized as JSON, including Linked Data, has led to
+      the development of YAML-LD.
+    </p>
+
+    <p>
+      <strong>Methods</strong><br>
+      This document defines constraints on YAML so that any YAML-LD
+      document can be represented in JSON-LD. This is necessary
+      because YAML is more expressive than JSON, in terms of both
+      available data types and document structure. This document
+      also registers the <code>application/ld+yaml</code> media type.
+    </p>
+
+    <p>
+      <strong>Results</strong><br>
+      This document provides a clear description of how to serialize
+      Linked Data in YAML. It also describes the basic concepts and
+      core requirements for implementing YAML-LD, including a
+      comparison of JSON versus YAML, the supported YAML features,
+      and encoding considerations.
+    </p>
+
+    <p>
+      <strong>Limitations</strong><br>
+      The YAML feature set is richer than that of JSON, and a number of
+      YAML features are not supported in this specification. However,
+      ground is laid for future development of a version of YAML-LD
+      which will support those features — via the Extended YAML-LD
+      Profile.
+    </p>
+    <p>
+      <strong>Conclusions</strong><br>
+      YAML-LD offers an efficient way to encode Linked Data in a
+      variety of programming languages which can use YAML.
+    </p>
+
+    <p>
+      <strong>An introductory YAML-LD example</strong> is presented below.
+
+      </p><div class="example" id="example-basic-yaml-ld-document">
+        <div class="marker">
+    <a class="self-link" href="#example-basic-yaml-ld-document">Example<bdi> 1</bdi></a><span class="example-title">: Basic YAML-LD document</span>
+  </div> <pre class="yaml" data-content-type="application/ld+yaml" aria-busy="false"><code class="hljs">"@context":
+  - https://json-ld.org/contexts/dollar-convenience.jsonld
+  - "@base": https://json-ld.github.io/yaml-ld/spec/
+    rdfs: http://www.w3.org/2000/01/rdf-schema#
+    schema: https://schema.org/
+    license:
+      "@type": "@id"
+
+$id: https://json-ld.github.io/yaml-ld/spec/
+rdfs:label: YAML-LD
+license: https://spdx.org/licenses/W3C.html
+schema:hasPart:
+  - rdfs:label: Abstract
+  - rdfs:label: Status of This Document
+  - rdfs:label: Introduction</code></pre>
+      </div>
+
+    <p></p>
+  </section>
+
+  <section id="sotd" class="introductory"><h2>Status of This Document</h2><p>
+      This specification was published by the
+      <a href="https://www.w3.org/groups/cg/json-ld">JSON for Linking Data Community Group</a>. It is not a W3C Standard nor is it
+      on the W3C Standards Track.
+      
+            Please note that under the
+            <a href="https://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>
+            other conditions apply.
+          
+      Learn more about
+      <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
+    </p>
+    <p>This document has been developed by the
+      <a href="https://www.w3.org/community/json-ld/">JSON-LD Community Group</a>.</p>
+  <p>
+    <a href="https://github.com/json-ld/yaml-ld/issues/">GitHub Issues</a> are preferred for
+          discussion of this specification.
+        
+    Alternatively, you can send comments to our mailing list.
+          Please send them to
+          <a href="mailto:public-linked-json@w3.org">public-linked-json@w3.org</a>
+          (<a href="mailto:public-linked-json-request@w3.org?subject=subscribe">subscribe</a>,
+          <a href="https://lists.w3.org/Archives/Public/public-linked-json/">archives</a>).
+        
+  </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#how-to-read-this-document"><bdi class="secno">1.1 </bdi>How to read this document</a></li><li class="tocline"><a class="tocxref" href="#terminology"><bdi class="secno">1.2 </bdi>Terminology</a></li><li class="tocline"><a class="tocxref" href="#namespace-prefixes"><bdi class="secno">1.3 </bdi>Namespace Prefixes</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">2. </bdi>Conformance</a></li><li class="tocline"><a class="tocxref" href="#basic-concepts"><bdi class="secno">3. </bdi>Basic Concepts</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#json-vs-yaml"><bdi class="secno">3.1 </bdi>JSON vs YAML comparison</a></li></ol></li><li class="tocline"><a class="tocxref" href="#core-requirements"><bdi class="secno">4. </bdi>Core Requirements</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#supported-yaml-features"><bdi class="secno">4.1 </bdi>YAML features supported by YAML-LD</a></li><li class="tocline"><a class="tocxref" href="#encoding"><bdi class="secno">4.2 </bdi>Encoding</a></li><li class="tocline"><a class="tocxref" href="#comments"><bdi class="secno">4.3 </bdi>Comments</a></li><li class="tocline"><a class="tocxref" href="#anchors-aliases"><bdi class="secno">4.4 </bdi>Anchors and Aliases</a></li><li class="tocline"><a class="tocxref" href="#mapping-key-types"><bdi class="secno">4.5 </bdi>Mapping Key Types</a></li></ol></li><li class="tocline"><a class="tocxref" href="#sec"><bdi class="secno">5. </bdi>Security Considerations</a></li><li class="tocline"><a class="tocxref" href="#int"><bdi class="secno">6. </bdi>Interoperability Considerations</a></li><li class="tocline"><a class="tocxref" href="#iana"><bdi class="secno">A. </bdi>IANA Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#application-ld-yaml"><bdi class="secno">A.1 </bdi>application/ld+yaml</a></li></ol></li><li class="tocline"><a class="tocxref" href="#best-practices"><bdi class="secno">B. </bdi>Best Practices</a></li><li class="tocline"><a class="tocxref" href="#comments-as-whitespace"><bdi class="secno">C. </bdi>Why are comments treated as whitespace?</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#consistency"><bdi class="secno">C.1 </bdi>Consistency</a></li><li class="tocline"><a class="tocxref" href="#predictability"><bdi class="secno">C.2 </bdi>Predictability</a></li></ol></li><li class="tocline"><a class="tocxref" href="#streams"><bdi class="secno">D. </bdi>Streams</a></li><li class="tocline"><a class="tocxref" href="#extended-profile"><bdi class="secno">E. </bdi>Extended YAML-LD Profile</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#motivation"><bdi class="secno">E.1 </bdi>Motivation</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#specify-node-type"><bdi class="secno">E.1.1 </bdi>Specify node <code>@type</code></a></li><li class="tocline"><a class="tocxref" href="#reduce-duplication"><bdi class="secno">E.1.2 </bdi>Reduce duplication</a></li></ol></li><li class="tocline"><a class="tocxref" href="#approaches"><bdi class="secno">E.2 </bdi>Approaches</a></li><li class="tocline"><a class="tocxref" href="#extended-internal-representation-0"><bdi class="secno">E.3 </bdi>Extended Internal Representation</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conversion-to-ir"><bdi class="secno">E.3.1 </bdi>Conversion to the Internal Representation</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#convert-stream"><bdi class="secno">E.3.1.1 </bdi>Converting a <span data-cite="YAML#streams" data-link-type="dfn" class="formerLink">YAML stream</span></a></li><li class="tocline"><a class="tocxref" href="#convert-document"><bdi class="secno">E.3.1.2 </bdi>Converting a <span data-cite="YAML#documents" data-link-type="dfn" class="formerLink">YAML document</span></a></li><li class="tocline"><a class="tocxref" href="#convert-seq"><bdi class="secno">E.3.1.3 </bdi>Converting a <span data-cite="YAML#sequence" data-link-type="dfn" class="formerLink">YAML sequence</span></a></li><li class="tocline"><a class="tocxref" href="#convert-mapping"><bdi class="secno">E.3.1.4 </bdi>Converting a <span data-cite="YAML#mapping" data-link-type="dfn" class="formerLink">YAML mapping</span></a></li><li class="tocline"><a class="tocxref" href="#convert-scalar"><bdi class="secno">E.3.1.5 </bdi>Converting a <span data-cite="YAML#scalar" data-link-type="dfn" class="formerLink">YAML scalar</span></a></li><li class="tocline"><a class="tocxref" href="#convert-alias"><bdi class="secno">E.3.1.6 </bdi>Converting a YAML <span data-cite="YAML#alias-nodes" data-link-type="dfn" class="formerLink">alias node</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#conversion-to-yaml"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#convert-ir"><bdi class="secno">E.3.2.1 </bdi>Converting From the Internal Representation</a></li></ol></li><li class="tocline"><a class="tocxref" href="#profiles"><bdi class="secno">E.3.3 </bdi>Application Profiles</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#yaml-ld-json-profile"><bdi class="secno">E.3.3.1 </bdi>YAML-LD Basic Profile</a></li><li class="tocline"><a class="tocxref" href="#yaml-ld-extended-profile"><bdi class="secno">E.3.3.2 </bdi>YAML-LD Extended Profile</a><ol class="toc"></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#api"><bdi class="secno">E.3.4 </bdi>The Application Programming Interface</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#jsonldprocessor"><bdi class="secno">E.3.4.1 </bdi>JsonLdProcessor</a></li><li class="tocline"><a class="tocxref" href="#jsonldoptions"><bdi class="secno">E.3.4.2 </bdi>JsonLdOptions</a></li><li class="tocline"><a class="tocxref" href="#remote-document-and-context-retrieval"><bdi class="secno">E.3.4.3 </bdi>Remote Document and Context Retrieval</a></li><li class="tocline"><a class="tocxref" href="#yamllderrorcode"><bdi class="secno">E.3.4.4 </bdi>YamlLdErrorCode</a></li></ol></li><li class="tocline"><a class="tocxref" href="#implementations"><bdi class="secno">E.3.5 </bdi>Implementations</a></li></ol></li><li class="tocline"><a class="tocxref" href="#convert-extended-yaml-ld-to-basic-yaml-ld-and-back"><bdi class="secno">E.4 </bdi>Convert Extended YAML-LD to Basic YAML-LD and back</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#tags-to-types"><bdi class="secno">E.4.1 </bdi>YAML <code>!tags</code> → <code>@type</code> declarations</a></li><li class="tocline"><a class="tocxref" href="#resolve-anchors-aliases"><bdi class="secno">E.4.2 </bdi><code>&amp;anchors</code> and <code>*aliases</code></a></li></ol></li><li class="tocline"><a class="tocxref" href="#frag"><bdi class="secno">E.5 </bdi>Fragment identifiers</a></li></ol></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">F. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">F.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">F.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+
+  <section id="introduction"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div>
+    
+    <p>
+      [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>] is a JSON-based format to serialize Linked Data.
+      In recent years, [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>] has emerged as a more concise format
+      to represent information that had previously been serialized as [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>],
+      including API specifications, data schemas, and Linked Data.
+    </p>
+
+    <p>
+      This document defines YAML-LD as a set of conventions
+      on top of YAML which specify how to serialize Linked Data [<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>] as [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>]
+      based on JSON-LD syntax, semantics, and APIs.
+    </p>
+
+    <p>
+      Since YAML is more expressive than JSON,
+      both in the available data types and in the document structure
+      (see [<cite><a class="bibref" data-link-type="biblio" href="#bib-i-d.ietf-httpapi-yaml-mediatypes" title="YAML Media Type">I-D.ietf-httpapi-yaml-mediatypes</a></cite>]),
+      this document identifies constraints on YAML
+      such that any <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-1">YAML-LD document</a> can be represented in JSON-LD.
+    </p>
+
+    <div class="note" id="issue-container-generatedID"><div role="heading" class="ednote-title marker" id="h-ednote" aria-level="3"><span>Editor's note</span></div><div class="">
+      See YAML-LD description of this spec at
+      <a href="data/spec.yaml" target="_blank">
+        <code>spec.yaml</code>
+      </a>.
+    </div></div>
+
+  <section class="informative" id="how-to-read-this-document"><div class="header-wrapper"><h3 id="x1-1-how-to-read-this-document"><bdi class="secno">1.1 </bdi>How to read this document</h3><a class="self-link" href="#how-to-read-this-document" aria-label="Permalink for Section 1.1"></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>
+      To understand the basics of this specification, one must be familiar with the following:
+    </p>
+    <ul>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>] data markup language, which is the underlying syntax for YAML-LD</li>
+      <li>basic Linked Data [<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>] principles</li>
+    </ul>
+
+    <p>
+      This document is intended primarily for two main audiences, as described below.
+    </p>
+
+    <ul>
+      <li>
+        <strong>Software developers</strong> who want to —
+        <ul>
+          <li>encode Linked Data in a variety of programming languages which can use YAML</li>
+          <li>convert existing YAML to YAML-LD</li>
+          <li>understand the design decisions and language syntax for YAML-LD</li>
+          <li>implement processors and APIs for YAML-LD</li>
+          <li>generate or consume Linked Data, an RDF Graph, or an RDF Dataset in a YAML syntax</li>
+        </ul>
+
+        <p>Among related technologies, JSON-LD familiarity would be required to
+           build most YAML-LD capable applications, while RDF familiarity is only
+           required when it is desired to convert YAML-LD to RDF graphs, or vice
+           versa.
+        </p>
+      </li>
+      <li>
+        <p>
+          <strong>Other professionals, both IT and otherwise</strong> who want to read and/or produce Linked Data documents
+          in YAML-LD format. Such documents can be —
+        </p>
+
+        <ul>
+          <li>consumed by programming systems capable of understanding YAML-LD</li>
+          <li>transformed with JSON-LD framing algorithms</li>
+          <li>published on the Web for human and machine consumption</li>
+        </ul>
+
+        <p>
+          For these users, familiarity with JSON-LD is not required, but understanding of Linked Data principles
+          might be beneficial.
+        </p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="informative" id="terminology"><div class="header-wrapper"><h3 id="x1-2-terminology"><bdi class="secno">1.2 </bdi>Terminology</h3><a class="self-link" href="#terminology" aria-label="Permalink for Section 1.2"></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>This document uses the following terms as defined in external specifications
+      and defines terms specific to JSON-LD.</p>
+
+    <p>A <dfn id="dfn-yaml-ld-stream" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">YAML-LD stream</dfn> is a <a data-no-xref="" href="https://yaml.org/spec/1.2.2/#92-streams">YAML stream</a>
+      of <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-2">YAML-LD documents</a>.
+    </p>
+    
+    <p>A <dfn data-plurals="yaml-ld documents" id="dfn-yaml-ld-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">YAML-LD document</dfn> is any <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a> from
+      which a conversion to [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>] produces
+      a valid <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a> which can be interpreted as [<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>].
+    </p>
+
+    <p>
+      The term <dfn data-no-xref="" id="dfn-media-type" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.rfc-editor.org/rfc/rfc6838#">media type</a></dfn> is imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6838" title="Media Type Specifications and Registration Procedures">RFC6838</a></cite>].</p>
+    <p>
+      The term
+      <dfn data-no-xref="" id="dfn-json" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.rfc-editor.org/rfc/rfc8259#section-2">JSON</a></dfn> is imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>].</p>
+    <p>The term
+      <dfn data-no-xref="" data-plurals="json documents" id="dfn-json-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">JSON document</dfn> represents a serialization of a resource
+      conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>] grammar.</p>
+
+    <p>
+      The terms
+      <dfn data-no-xref="" id="dfn-json-ld-document" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a></dfn>, and
+      <dfn data-no-xref="" data-plurals="value objects" id="dfn-value-object" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/json-ld11/#dfn-value-object">value object</a></dfn>
+      are imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>].
+    </p>
+
+
+    <p>
+      The terms
+      <dfn data-lt="JSON-LD internal representation" data-no-xref="" id="dfn-json-ld-internal-representation" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a></dfn>, and
+      <dfn id="dfn-documentloader" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/json-ld11/#dom-jsonldoptions-documentloader">documentLoader</a></dfn>
+      are imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>].
+    </p>
+
+    <p>The terms
+      <dfn data-no-xref="" data-plurals="arrays" id="dfn-array" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#list">array</a></dfn>,
+      <dfn data-no-xref="" id="dfn-boolean" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#boolean">boolean</a></dfn>,
+      <dfn data-no-xref="" data-plurals="maps" id="dfn-map" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#ordered-map">map</a></dfn>,
+      <dfn data-lt="entry" data-no-xref="" id="dfn-entry" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#map-entry">map entry</a></dfn>,
+      <dfn data-no-xref="" data-plurals="nulls" id="dfn-null" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#nulls">null</a></dfn>, and
+      <dfn data-no-xref="" data-plurals="strings" id="dfn-string" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://infra.spec.whatwg.org/#javascript-string">string</a></dfn>
+      are imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-infra" title="Infra Standard">INFRA</a></cite>].</p>
+
+    <p>
+      The term
+      <dfn data-lt="number|JSON number" data-no-xref="" data-plurals="numbers" id="dfn-number" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://tc39.es/ecma262/multipage/#sec-terms-and-definitions-number-value">number</a></dfn>
+      is imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-ecmascript" title="ECMAScript Language Specification">ECMASCRIPT</a></cite>].
+    </p>
+
+    <p>
+      The terms <dfn data-no-xref="" id="dfn-yaml" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#">YAML</a></dfn>,
+      <dfn data-lt="representation graph" data-no-xref="" id="dfn-representation-graph" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#representation-graph">YAML representation graph</a></dfn>,
+      <dfn data-no-xref="" data-lt="stream" data-plurals="yaml streams" id="dfn-stream" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a></dfn>,
+      <dfn data-no-xref="" data-lt="directive" data-plurals="yaml directives|directives" id="dfn-directive" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#directives">YAML directive</a></dfn>,
+      <dfn data-no-xref="" data-plurals="tag directives" id="dfn-tag-directive" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#tag-directives">TAG directive</a></dfn>,
+      <dfn data-no-xref="" data-lt="documents" data-plurals="yaml documents" id="dfn-documents" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#documents">YAML document</a></dfn>,
+      <dfn data-no-xref="" id="dfn-yaml-sequence" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#sequence">YAML sequence</a></dfn>
+      (either
+      <dfn data-no-xref="" data-plurals="block sequences" id="dfn-block-sequence" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#block-sequences">block sequence</a></dfn> or
+      <dfn data-no-xref="" data-plurals="flow sequences" id="dfn-flow-sequence" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#flow-sequences">flow sequence</a></dfn>),
+      <dfn data-no-xref="" id="dfn-yaml-mapping" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a></dfn>
+      (either
+      <dfn data-no-xref="" data-plurals="block mappings" id="dfn-block-mapping" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#block-mappings">block mapping</a></dfn> or
+      <dfn data-no-xref="" data-plurals="flow mappings" id="dfn-flow-mapping" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#flow-mappings">flow mapping</a></dfn>),
+      <dfn data-no-xref="" data-lt="YAML node" data-plurals="yaml nodes" id="dfn-yaml-node" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#nodes">node</a></dfn>,
+      <dfn data-no-xref="" data-lt="YAML scalar" data-plurals="yaml scalars" id="dfn-yaml-scalar" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#scalar">scalar</a></dfn>,
+      <dfn data-lt="anchor name|anchored nodes" data-no-xref="" data-plurals="node anchors|anchor names" id="dfn-anchor-name" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#node-anchors">node anchor</a></dfn>,
+      <dfn data-no-xref="" data-plurals="node tag" id="dfn-node-tags" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a></dfn>,
+      and <dfn data-no-xref="" data-plurals="alias nodes" id="dfn-alias-node" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://yaml.org/spec/1.2.2/#alias-nodes">alias node</a></dfn>,
+      are imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>].</p>
+
+    <p>The term
+      <dfn data-no-xref="" id="dfn-content-negotiation" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://httpwg.org/specs/rfc9110.html#content.negotiation">content negotiation</a></dfn>
+      is imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9110" title="HTTP Semantics">RFC9110</a></cite>].
+    </p>
+
+    <p>
+      The terms
+      <dfn data-no-xref="" data-plurals="rdf literals" id="dfn-rdf-literal" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a></dfn>,
+      <dfn data-no-xref="" data-plurals="language-tagged strings" id="dfn-language-tagged-string" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged string</a></dfn>,
+      <dfn data-no-xref="" id="dfn-datatype-iri" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a></dfn>, and
+      <dfn data-no-xref="" id="dfn-language-tag" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a></dfn>
+      are imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-rdf11-concepts" title="RDF 1.1 Concepts and Abstract Syntax">RDF11-CONCEPTS</a></cite>].
+    </p>
+
+    <p>The terms
+      <dfn data-no-xref="" id="dfn-fragment" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">fragment</a></dfn> and
+      <dfn data-no-xref="" id="dfn-fragment-identifier" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">fragment identifier</a></dfn>
+      in this document are to be interpreted as in [<cite><a class="bibref" data-link-type="biblio" href="#bib-uri" title="Uniform Resource Identifier (URI): Generic Syntax">URI</a></cite>].
+    </p>
+
+    <p>The term <dfn data-no-xref="" id="dfn-linked-data" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/DesignIssues/LinkedData.html#">Linked Data</a></dfn> is imported from [<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>].
+    </p>
+  </section>
+
+  <section class="informative" id="namespace-prefixes"><div class="header-wrapper"><h3 id="x1-3-namespace-prefixes"><bdi class="secno">1.3 </bdi>Namespace Prefixes</h3><a class="self-link" href="#namespace-prefixes" aria-label="Permalink for Section 1.3"></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>This specification makes use of the following namespace prefixes:</p>
+    <table class="simple">
+      <thead><tr>
+        <th>Prefix</th>
+        <th>IRI</th>
+      </tr></thead>
+      <tbody>
+        <tr>
+          <td>ex</td>
+          <td>https://example.org/</td>
+        </tr>
+        <tr>
+          <td>i18n</td>
+          <td>https://www.w3.org/ns/i18n#</td>
+        </tr>
+        <tr>
+          <td>rdf</td>
+          <td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td>
+        </tr>
+        <tr>
+          <td>rdfs</td>
+          <td>http://www.w3.org/2000/01/rdf-schema#</td>
+        </tr>
+        <tr>
+          <td>xsd</td>
+          <td>http://www.w3.org/2001/XMLSchema#</td>
+        </tr>
+        <tr>
+          <td>schema</td>
+          <td>https://schema.org/</td>
+        </tr>
+        <tr>
+          <td>prov</td>
+          <td>http://www.w3.org/ns/prov#</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="note" id="issue-container-generatedID-0"><div role="heading" class="ednote-title marker" id="h-ednote-0" aria-level="4"><span>Editor's note</span></div><div class="">
+      See YAML-LD version of this table at
+      <a href="data/namespace-prefixes.yaml" target="_blank">
+        <code>namespace-prefixes.yaml</code>
+      </a>.
+    </div></div>
+
+    <p>These are used within this document as part of a <a href="https://www.w3.org/TR/json-ld11/#dfn-compact-iri">compact IRI</a>
+      as a shorthand for the resulting <a href="https://www.rfc-editor.org/rfc/rfc3987#section-2">IRI</a>, such as <code>schema:url</code>
+      used to represent <code>https://schema.org/url</code>.
+    </p>
+  </section>
+  </section>
+
+<section id="conformance"><div class="header-wrapper"><h2 id="x2-conformance"><bdi class="secno">2. </bdi>Conformance</h2><a class="self-link" href="#conformance" aria-label="Permalink for Section 2."></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">RECOMMENDED</em>, and <em class="rfc2119">SHOULD</em> in this document
+        are to be interpreted as described in
+        <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all capitals, as shown here.
+      </p>
+  <p>
+    A <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-3">YAML-LD document</a> complies with
+    the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-1">YAML-LD Basic profile</a> of this specification
+    if it follows the normative statements from this specification
+    and can be transformed into a JSON-LD representation,
+    then back to a conforming YAML-LD document,
+    without loss of semantic information.
+  </p>
+
+  <p>
+    For convenience, normative statements for documents are often phrased
+    as statements on the properties of the document.
+  </p>
+</section>
+
+  <section id="basic-concepts" class="informative"><div class="header-wrapper"><h2 id="x3-basic-concepts"><bdi class="secno">3. </bdi>Basic Concepts</h2><a class="self-link" href="#basic-concepts" aria-label="Permalink for Section 3."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <section id="json-vs-yaml"><div class="header-wrapper"><h3 id="x3-1-json-vs-yaml-comparison"><bdi class="secno">3.1 </bdi>JSON vs YAML comparison</h3><a class="self-link" href="#json-vs-yaml" aria-label="Permalink for Section 3.1"></a></div>
+      
+
+      <p>YAML is more flexible than JSON, as illustrated by comparison table below.</p>
+
+      <table class="simple">
+        <thead>
+        <tr>
+          <th>Features</th>
+          <th>[<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>]</th>
+          <th>[<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>]</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th colspan="3">Allowed encodings</th>
+        </tr>
+
+        <tr>
+          <th>UTF-8</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-8.1">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#52-character-encodings">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>UTF-16</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-8.1">❌</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#52-character-encodings">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>UTF-32</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-8.1">❌</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#52-character-encodings">✅</a></td>
+        </tr>
+
+        <tr>
+          <th colspan="3">Native data types</th>
+        </tr>
+
+        <tr>
+          <th><code>{}</code> object</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-4">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#3211-nodes">✅</a></td>
+        </tr>
+
+        <tr>
+          <th><code>[]</code> array</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-5">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#3211-nodes">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>string</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-7">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#3211-nodes">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>number</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-6">✅</a></td>
+          <td>
+            ✅
+            <br>
+            <a href="https://yaml.org/spec/1.2.2/#10213-integer">integer</a>
+            <br>
+            <a href="https://yaml.org/spec/1.2.2/#10214-floating-point">floating
+            point</a></td>
+        </tr>
+
+        <tr>
+          <th>bool</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-3">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#10212-boolean">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>null</th>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc8259#section-3">✅</a></td>
+          <td><a href="https://yaml.org/spec/1.2.2/#10211-null">✅</a></td>
+        </tr>
+
+        <tr>
+          <th colspan="3">Features</th>
+        </tr>
+
+        <tr>
+          <th>Custom types</th>
+          <td>❌</td>
+          <td>✅ via <a href="https://yaml.org/spec/1.2.2/#tags">tags</a></td>
+        </tr>
+
+        <tr>
+          <th>Cycles</th>
+          <td>❌</td>
+          <td><a href="https://yaml.org/spec/1.2.2/#321-representation-graph">✅</a></td>
+        </tr>
+        <tr>
+          <th>Documents per file</th>
+          <td>1</td>
+          <td>⩾ 1 via <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a></td>
+        </tr>
+
+        <tr>
+          <th>Comments</th>
+          <td>❌</td>
+          <td><a href="https://yaml.org/spec/1.2.2/#3233-comments">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>Anchors &amp; aliases</th>
+          <td>❌</td>
+          <td><a href="https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases">✅</a></td>
+        </tr>
+
+        <tr>
+          <th>Mapping key types</th>
+          <td><code>string</code></td>
+          <td>
+            <a href="https://yaml.org/spec/1.2.2/#3211-nodes">Any type representable in YAML</a>, from strings to mappings
+          </td>
+        </tr>
+        </tbody>
+      </table>
+
+      <div class="note" id="issue-container-generatedID-1"><div role="heading" class="ednote-title marker" id="h-ednote-1" aria-level="4"><span>Editor's note</span></div><div class="">
+        See YAML-LD version of this table at
+        <a href="data/json-vs-yaml.yaml" target="_blank">
+          <code>json-vs-yaml.yaml</code>
+        </a>.
+    </div></div>
+    </section>
+
+    <p>
+      The first goal of this specification is to allow a <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a> to be
+      processed and serialized into YAML, and then back into JSON-LD, without
+      losing any semantic information.</p>
+
+    <p>This is always possible because</p>
+
+    <ul>
+      <li>a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">YAML representation graph</a> can always represent a tree</li>
+      <li>set of JSON data types is a subset of the set of YAML data types</li>
+      <li>JSON encoding is UTF-8.</li>
+    </ul>
+
+    <p>Example: The JSON-LD document below</p>
+    <div class="example" id="example-basic-json-ld-document">
+        <div class="marker">
+    <a class="self-link" href="#example-basic-json-ld-document">Example<bdi> 2</bdi></a><span class="example-title">: Basic JSON-LD document</span>
+  </div> <pre data-result-for="Basic YAML-LD document" data-content-type="application/ld+json" aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://schema.org"</span>,
+
+  <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"https://w3.org/yaml-ld/"</span>,
+  <span class="hljs-attr">"@type"</span>: <span class="hljs-string">"WebContent"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"YAML-LD"</span>,
+  <span class="hljs-attr">"author"</span>: {
+    <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"https://www.w3.org/community/json-ld"</span>,
+    <span class="hljs-attr">"name"</span>: <span class="hljs-string">"JSON-LD Community Group"</span>
+  }
+}</code></pre>
+      </div>
+
+    <p>
+      Can be serialized as YAML as follows.
+      Note that entries
+      starting with  <code>@</code> need to be enclosed in quotes
+      because <code>@</code> is a reserved character in YAML.
+    </p>
+
+    <div class="example" id="example-basic-yaml-ld-document-0">
+        <div class="marker">
+    <a class="self-link" href="#example-basic-yaml-ld-document-0">Example<bdi> 3</bdi></a><span class="example-title">: Basic YAML-LD document</span>
+  </div> <pre class="yaml" data-content-type="application/ld+yaml" aria-busy="false"><code class="hljs">"@context": https://schema.org
+
+"@id": https://w3.org/yaml-ld/
+"@type": WebContent
+name: YAML-LD
+author:
+  "@id": https://www.w3.org/community/json-ld
+  name: JSON-LD Community Group</code></pre>
+      </div>
+
+    <p>
+      This document is based on YAML 1.2.2,
+      but YAML-LD is not tied to a specific version of YAML.
+      Implementers concerned about features related to a specific YAML version
+      can specify it in documents using the <code>%YAML</code> directive
+      (see <a href="#int" class="sectionRef sec-ref"><bdi class="secno">6. </bdi>Interoperability Considerations</a>).
+    </p>
+  </section>
+
+  <section id="core-requirements" class="normative"><div class="header-wrapper"><h2 id="x4-core-requirements"><bdi class="secno">4. </bdi>Core Requirements</h2><a class="self-link" href="#core-requirements" aria-label="Permalink for Section 4."></a></div>
+    
+
+    <section id="supported-yaml-features" class="informative"><div class="header-wrapper"><h3 id="x4-1-yaml-features-supported-by-yaml-ld"><bdi class="secno">4.1 </bdi>YAML features supported by YAML-LD</h3><a class="self-link" href="#supported-yaml-features" aria-label="Permalink for Section 4.1"></a></div><p><em>This section is non-normative.</em></p>
+      
+
+      <dl>
+        <dt>Encoding</dt>
+        <dd>UTF-8 <a href="#encoding">only</a>.</dd>
+
+        <dt>Native data types</dt>
+        <dd>Every native data type that the YAML-LD parser supports.</dd>
+
+        <dt>Tags</dt>
+        <dd>Ignored.</dd>
+
+        <dt>Comments</dt>
+        <dd><a href="#comments">Treated as whitespace</a>.</dd>
+
+        <dt>Anchors &amp; aliases</dt>
+        <dd>Resolved by YAML parser. Anchors &amp; alias names are ignored.</dd>
+
+        <dt>Cycles defined using anchors &amp; aliases</dt>
+        <dd>Not permitted.</dd>
+
+        <dt>YAML Streams</dt>
+        <dd>Not supported.</dd>
+
+        <dt>Mapping key types other than <code>string</code></dt>
+        <dd><a href="#mapping-key-types">Not supported.</a></dd>
+      </dl>
+
+      <p>
+        Perspectives for support of the additional YAML features are analyzed in
+        <a href="#extended-profile">Extended Profile</a> informative addendum to this specification.
+      </p>
+    </section>
+
+    <section id="encoding"><div class="header-wrapper"><h3 id="x4-2-encoding"><bdi class="secno">4.2 </bdi>Encoding</h3><a class="self-link" href="#encoding" aria-label="Permalink for Section 4.2"></a></div>
+    
+
+    <p id="cr-utf8" data-tests="
+      manifest.html#cr-utf8-1-positive,
+      manifest.html#cr-utf8-2-negative">
+      A <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-4">YAML-LD document</a> <em class="rfc2119">MUST</em> be encoded in UTF-8,
+      to ensure interoperability with [<cite><a class="bibref" data-link-type="biblio" href="#bib-json" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite>];
+      otherwise, an
+      <a href="#dom-yamllderrorcode-invalid-encoding" class="internalDFN" data-link-type="idl" id="ref-for-dom-yamllderrorcode-invalid-encoding-1"><code>invalid-encoding</code></a>
+      <em class="rfc2119">MUST</em> be detected, and processing aborted.
+    </p>
+    </section>
+
+    <section id="comments"><div class="header-wrapper"><h3 id="x4-3-comments"><bdi class="secno">4.3 </bdi>Comments</h3><a class="self-link" href="#comments" aria-label="Permalink for Section 4.3"></a></div>
+      
+      <p id="cr-comments" data-tests="manifest.html#cr-comments-1-positive">
+        Comments in <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-5">YAML-LD documents</a> are treated as white space.
+      </p>
+
+      <p>
+        See Interoperability considerations of [<cite><a class="bibref" data-link-type="biblio" href="#bib-i-d.ietf-httpapi-yaml-mediatypes" title="YAML Media Type">I-D.ietf-httpapi-yaml-mediatypes</a></cite>]
+        for more details.
+      </p>
+    </section>
+
+    <section id="anchors-aliases"><div class="header-wrapper"><h3 id="x4-4-anchors-and-aliases"><bdi class="secno">4.4 </bdi>Anchors and Aliases</h3><a class="self-link" href="#anchors-aliases" aria-label="Permalink for Section 4.4"></a></div>
+    
+    <p id="aa-information" data-tests="">
+      Since <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">anchor names</a> are a serialization detail, such anchors
+      <em class="rfc2119">MUST NOT</em> be used to convey relevant information,
+      <em class="rfc2119">MAY</em> be altered when processing the document,
+      and <em class="rfc2119">MAY</em> be dropped when interpreting the document as JSON-LD.
+    </p>
+
+    <p id="aa-cycles" data-tests="
+      manifest.html#aa-cycles-1-positive,
+      manifest.html#aa-cycles-2-negative,
+      manifest.html#aa-cycles-3-positive">
+      A <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-6">YAML-LD document</a> <em class="rfc2119">MAY</em> contain <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">anchored nodes</a> and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias nodes</a>,
+      but its <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">representation graph</a> <em class="rfc2119">MUST NOT</em> contain cycles;
+      otherwise, a
+      <a href="https://www.w3.org/TR/json-ld11-api/#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
+      error <em class="rfc2119">MUST</em> be detected, and processing aborted.
+    </p>
+
+    <p>
+      When interpreting the document as JSON-LD,
+      alias nodes <em class="rfc2119">MUST</em> be resolved by value to their target nodes.
+    </p>
+
+    <p>
+      The <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-7">YAML-LD document</a> in the following example
+      contains alias nodes for the <code>{"@id": "country:US"}</code> object:
+    </p>
+
+    <div class="example" id="example-with-anchors">
+        <div class="marker">
+    <a class="self-link" href="#example-with-anchors">Example<bdi> 4</bdi></a><span class="example-title">: YAML-LD with node anchors</span>
+  </div> <pre class="yaml" data-content-type="application/ld+yaml" aria-busy="false"><code class="hljs">"@context":
+  "@import": https://schema.org
+  country: https://example.org/country/
+
+"@included":
+  - &amp;US
+    "@id": country:US
+  - "@id": https://www.w3.org/community/json-ld
+    "@type": Organization
+    member:
+      - "@id": https://github.com/gkellogg
+        "@type": Person
+        name: Gregg Kellogg
+        country: *US
+      - "@id": https://github.com/BigBlueHat
+        "@type": Person
+        name: Benjamin Young
+        country: *US
+    # - …</code></pre>
+      </div>
+
+    <p>
+      While the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">representation graph</a>
+      (and eventually the in-memory representation
+      of the data structure, e.g., a Python dictionary or a Java hashmap)
+      will still contain references between nodes,
+      the JSON-LD serialization will not — since, by the time it is formed,
+      all the anchors have been resolved, as shown below.
+    </p>
+
+    <div class="example" id="example-json-ld-resulting-from-yaml-with-node-anchors">
+        <div class="marker">
+    <a class="self-link" href="#example-json-ld-resulting-from-yaml-with-node-anchors">Example<bdi> 5</bdi></a><span class="example-title">: JSON-LD resulting from YAML with node anchors</span>
+  </div> <pre data-result-for="YAML-LD with node anchors" data-content-type="application/ld+json" aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"@context"</span>: {
+    <span class="hljs-attr">"@import"</span>: <span class="hljs-string">"https://schema.org"</span>,
+    <span class="hljs-attr">"country"</span>: <span class="hljs-string">"https://example.org/country/"</span>
+  },
+  <span class="hljs-attr">"@included"</span>: [
+    {
+      <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"country:US"</span>
+    },
+    {
+      <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"https://www.w3.org/community/json-ld"</span>,
+      <span class="hljs-attr">"@type"</span>: <span class="hljs-string">"Organization"</span>,
+      <span class="hljs-attr">"member"</span>: [
+        {
+          <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"https://github.com/gkellogg"</span>,
+          <span class="hljs-attr">"@type"</span>: <span class="hljs-string">"Person"</span>,
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Gregg Kellogg"</span>,
+          <span class="hljs-attr">"country"</span>: {
+            <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"country:US"</span>
+          }
+        },
+        {
+          <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"https://github.com/BigBlueHat"</span>,
+          <span class="hljs-attr">"@type"</span>: <span class="hljs-string">"Person"</span>,
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Benjamin Young"</span>,
+          <span class="hljs-attr">"country"</span>: {
+            <span class="hljs-attr">"@id"</span>: <span class="hljs-string">"country:US"</span>
+          }
+        },
+        …
+      ]
+    }
+  ]
+}</code></pre>
+      </div>
+    </section>
+
+    <section id="mapping-key-types"><div class="header-wrapper"><h3 id="x4-5-mapping-key-types"><bdi class="secno">4.5 </bdi>Mapping Key Types</h3><a class="self-link" href="#mapping-key-types" aria-label="Permalink for Section 4.5"></a></div>
+      
+
+      <p id="aa-mapping-key-types" data-tests="
+        manifest.html#cir-mapping-key-1-negative,
+        manifest.html#cir-mapping-key-2-negative,
+        manifest.html#cir-mapping-key-3-negative,
+        manifest.html#cir-mapping-key-4-negative,
+        manifest.html#cir-mapping-key-5-negative,
+      ">
+        Mapping key type <em class="rfc2119">MUST</em> be a <code>string</code>. Otherwise, a processing error is raised.
+      </p>
+    </section>
+  </section>
+
+  <section id="sec" class="informative"><div class="header-wrapper"><h2 id="x5-security-considerations"><bdi class="secno">5. </bdi>Security Considerations</h2><a class="self-link" href="#sec" aria-label="Permalink for Section 5."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>See <a href="https://www.w3.org/TR/json-ld11/#iana-security">Security considerations in JSON-LD 1.1</a>.
+      Also, see the YAML media type registration.</p>
+  </section>
+
+  <section id="int" class="informative"><div class="header-wrapper"><h2 id="x6-interoperability-considerations"><bdi class="secno">6. </bdi>Interoperability Considerations</h2><a class="self-link" href="#int" aria-label="Permalink for Section 6."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>
+      For general interoperability considerations on the serialization of
+      <a href="#dfn-json-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-json-document-1">JSON documents</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>], see YAML
+      and the Interoperability consideration of <code>application/yaml</code> [<cite><a class="bibref" data-link-type="biblio" href="#bib-i-d.ietf-httpapi-yaml-mediatypes" title="YAML Media Type">I-D.ietf-httpapi-yaml-mediatypes</a></cite>].
+    </p>
+    <p>
+      The YAML-LD format and the media type registration are not restricted to a specific
+      version of YAML,
+      but implementers that want to use YAML-LD with YAML versions
+      other than 1.2.2 need to be aware that the considerations and analysis provided
+      here, including interoperability and security considerations, are based
+      on the YAML 1.2.2 specification.
+    </p>
+  </section>
+
+  <section id="iana" class="appendix normative"><div class="header-wrapper"><h2 id="a-iana-considerations"><bdi class="secno">A. </bdi>IANA Considerations</h2><a class="self-link" href="#iana" aria-label="Permalink for Appendix A."></a></div>
+    
+
+    <p>This section has been submitted to the Internet Engineering Steering
+      Group (IESG) for review, approval, and registration with IANA.</p>
+    <p>
+      This section describes the information required to register the above media type according to [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6838" title="Media Type Specifications and Registration Procedures">RFC6838</a></cite>]
+    </p>
+
+    <section id="application-ld-yaml"><div class="header-wrapper"><h3 id="a-1-application-ld-yaml"><bdi class="secno">A.1 </bdi>application/ld+yaml</h3><a class="self-link" href="#application-ld-yaml" aria-label="Permalink for Appendix A.1"></a></div>
+    
+    <dl>
+      <dt>Type name:</dt>
+      <dd>application</dd>
+      <dt>Subtype name:</dt>
+      <dd>ld+yaml</dd>
+      <dt>Required parameters:</dt>
+      <dd>N/A</dd>
+      <dt>Optional parameters:</dt>
+      <dd>
+        <dl>
+          <dt><code>profile</code></dt>
+          <dd>
+            <p>A non-empty list of space-separated URIs identifying specific
+              constraints or conventions that apply to a <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-8">YAML-LD document</a> according to [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6906" title="The 'profile' Link Relation Type">RFC6906</a></cite>].
+              A profile does not change the semantics of the resource representation
+              when processed without profile knowledge, so that clients both with
+              and without knowledge of a profiled resource can safely use the same
+              representation. The <code>profile</code> parameter <em class="rfc2119">MAY</em> be used by
+              clients to express their preferences in the content negotiation process.
+              If the profile parameter is given, a server <em class="rfc2119">SHOULD</em> return a document that
+              honors the profiles in the list which it recognizes,
+              and <em class="rfc2119">MUST</em> ignore the profiles in the list which it does not recognize.
+              It is <em class="rfc2119">RECOMMENDED</em> that profile URIs are dereferenceable and provide
+              useful documentation at that URI. For more information and background
+              please refer to [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6906" title="The 'profile' Link Relation Type">RFC6906</a></cite>].</p>
+            <p>This specification allows the use of the <code>profile</code> parameters listed in
+              <a href="https://www.w3.org/TR/json-ld11/#iana-considerations"> and additionally defines the following:</a>
+            </p>
+            <dl>
+              <dt><code>http://www.w3.org/ns/json-ld#extended</code></dt>
+              <dd>To request or specify <a href="#extended-profile">extended</a> <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-9">YAML-LD document</a> form.
+                <div class="note" id="issue-container-generatedID-2"><div role="heading" class="ednote-title marker" id="h-ednote-2" aria-level="4"><span>Editor's note</span></div><div class="">
+                  This is a placeholder for specifying something like an
+                  <a href="#extended-profile">extended</a> <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-10">YAML-LD document</a> form
+                  making use of YAML-specific features.
+                </div></div></dd>
+            </dl>
+            <p>
+              When used as a <a href="https://www.rfc-editor.org/rfc/rfc4288#section-4.3">media type parameter</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc4288" title="Media Type Specifications and Registration Procedures">RFC4288</a></cite>]
+              in an <a href="https://httpwg.org/specs/rfc9110.html#rfc.section.12.5.1">HTTP Accept header field</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9110" title="HTTP Semantics">RFC9110</a></cite>],
+              the value of the <code>profile</code> parameter <em class="rfc2119">MUST</em> be enclosed in quotes (<code>"</code>) if it contains
+              special characters such as whitespace, which is required when multiple profile URIs are combined.</p>
+            <p>When processing the "profile" media type parameter, it is important to
+              note that its value contains one or more URIs and not IRIs. In some cases
+              it might therefore be necessary to convert between IRIs and URIs as specified in
+              <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5.1">section 3 Relationship between IRIs and URIs</a>
+              of [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3987" title="Internationalized Resource Identifiers (IRIs)">RFC3987</a></cite>].</p>
+          </dd>
+        </dl>
+      </dd>
+      <dt>Encoding considerations:</dt>
+      <dd>See <a href="https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html#">YAML media type</a>.</dd>
+      <dt id="iana-security">Security considerations:</dt>
+      <dd>See <a href="#sec" class="sectionRef sec-ref"><bdi class="secno">5. </bdi>Security Considerations</a>.</dd>
+      <dt>Interoperability considerations:</dt>
+      <dd>See <a href="#int" class="sectionRef sec-ref"><bdi class="secno">6. </bdi>Interoperability Considerations</a>.</dd>
+      <dt>Published specification:</dt>
+      <dd>http://www.w3.org/TR/yaml-ld</dd>
+      <dt>Applications that use this media type:</dt>
+      <dd>Any programming environment that requires the exchange of
+        directed graphs.
+      </dd>
+      <dt>Additional information:</dt>
+      <dd>
+        <dl>
+          <dt>Magic number(s):</dt>
+          <dd>See <code>application/yaml</code></dd>
+          <dt>File extension(s):</dt>
+          <dd>
+            <ul>
+              <li><code>.yaml</code></li>
+              <li><code>.yamlld</code></li>
+            </ul>
+          </dd>
+          <dt>Macintosh file type code(s):</dt>
+          <dd>TEXT</dd>
+        </dl>
+      </dd>
+      <dt>Person &amp; email address to contact for further information:</dt>
+      <dd>Philippe Le Hégaret &lt;plh@w3.org&gt;</dd>
+      <dt>Intended usage:</dt>
+      <dd>Common</dd>
+      <dt>Restrictions on usage:</dt>
+      <dd>N/A</dd>
+      <dt>Author(s):</dt>
+      <dd>Roberto Polli, Gregg Kellogg</dd>
+      <dt>Change controller:</dt>
+      <dd>W3C</dd>
+    </dl>
+    </section>
+  </section>
+
+    <section id="best-practices" class="informative"><div class="header-wrapper"><h2 id="b-best-practices"><bdi class="secno">B. </bdi>Best Practices</h2><a class="self-link" href="#best-practices" aria-label="Permalink for Section B."></a></div><p><em>This section is non-normative.</em></p>
+      
+
+      <p>Here, we propose to YAML-LD users a bit of advice which, although optional, might suggest one or two
+        useful thoughts.</p>
+
+       <div class="practice advisement"><a class="marker self-link" href="#bp-use-json-ld-best-practices"><bdi lang="en">Best Practice 1</bdi></a>: <span id="bp-use-json-ld-best-practices" class="practicelab">Follow JSON-LD best practices</span>
+          <p class="practicedesc">
+            
+            …in order to achieve a greater level of reusability, performance, and human friendliness among YAML-LD aware
+            systems. The [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld-bp" title="JSON-LD Best Practices">json-ld-bp</a></cite>] document is as relevant to YAML-LD as it is to [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>].
+          </p>
+       </div>
+
+      <div class="practice advisement"><a class="marker self-link" href="#bp-prebuilt-contexts"><bdi lang="en">Best Practice 2</bdi></a>: <span id="bp-prebuilt-contexts" class="practicelab">Do not force users to author contexts</span>
+        <p class="practicedesc">
+          
+
+          Instead, provide pre-built contexts that the user can reference by URL for a majority of common use cases.
+        </p>
+      </div>
+
+      <p>YAML-LD is intended to simplify the authoring of Linked Data for a wide range of domain experts; its target
+        audience is not comprised solely of IT professionals. [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>] is chosen as a medium to minimize syntactic noise,
+        and to keep the authored documents concise and clear. [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>] (and hence YAML-LD) Context comprises a special
+        language of its own. A requirement to <i>author</i> such a context would make the domain expert's job much
+        harder, which we, as system architects and developers, should try to avoid.</p>
+
+      <div class="practice advisement"><a class="marker self-link" href="#bp-conceal-contexts"><bdi lang="en">Best Practice 3</bdi></a>: <span id="bp-conceal-contexts" class="practicelab">Use a default context</span>
+        <p class="practicedesc">
+          
+        </p>
+
+        If most, or all, of a user's documents are based on one particular context, try to make it the default in order
+        to rescue the user from copy-pasting the same technical incantation from one document to another.
+      </div>
+
+      <p>For instance, according to [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>], the <code>expand()</code> method of a JSON-LD processor accepts an
+        <code>expandContext</code> argument which can be used to provide a default system context.</p>
+
+      <div class="practice advisement"><a class="marker self-link" href="#bp-alias-keywords"><bdi lang="en">Best Practice 4</bdi></a>: <span id="bp-alias-keywords" class="practicelab">Alias JSON-LD keywords</span>
+        <p class="practicedesc">
+          
+
+          If possible, map JSON-LD keywords containing the <code>@</code> character to keywords that do not contain it.
+        </p>
+      </div>
+
+      <p>The <code>@</code> character is reserved in YAML, and thus requires quoting (or escaping), as in the following
+        example:</p>
+
+      <div class="example" id="quoted-example">
+        <div class="marker">
+    <a class="self-link" href="#quoted-example">Example<bdi> 6</bdi></a><span class="example-title">: Example YAML-LD document with quoted keywords</span>
+  </div> <pre class="json" data-content-type="application/ld+yaml" aria-busy="false"><code class="hljs">"@context": https://schema.org
+"@id": https://w3.org/yaml-ld/
+"@type": WebContent</code></pre>
+      </div>
+
+      <p>
+        The need to quote these keywords has to be learnt, and introduces one more little irregularity to the document
+        author's life. Further, on most keyboard layouts, typing quotes will require <code>Shift</code>, which reduces typing speed,
+        albeit slightly.
+      </p>
+
+      <p>
+        In order to avoid this, the context might introduce custom mappings for JSON-LD keywords —
+        to make authoring more convenient. The exact mapping might vary depending on the domain, but we provide two
+        examples, both published at <a href="https://json-ld.org">json-ld.org</a>:
+      </p>
+
+      <ul>
+        <li>
+          <a href="https://json-ld.org/contexts/convenience.jsonld"><code>convenience.jsonld</code></a>
+          maps <code>@id</code> → <code>id</code> and so on, removing the <code>@</code> character
+        </li>
+        <li>
+          <a href="https://json-ld.org/contexts/dollar-convenience.jsonld"><code> dollar-convenience.jsonld </code></a>
+          maps <code>@id</code> → <code>$id</code> and so on, replacing <code>@</code> with <code>$</code>.
+        </li>
+      </ul>
+
+      <div class="practice advisement"><a class="marker self-link" href="#bp-convenience-context"><bdi lang="en">Best Practice 5</bdi></a>: <span id="bp-convenience-context" class="practicelab">Use a <dfn id="dfn-convenience-context" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Convenience Context</dfn></span>
+        <p class="practicedesc">
+          
+        </p><p>
+          YAML-LD users may use a JSON-LD context provided as part of this specification, or a similar custom context,
+          to improve the authoring experience and readability.
+        </p>
+      </div>
+
+      <p>
+        Unfortunately, <code>@context</code> keyword cannot be aliased as per JSON-LD specification and will have
+        to stay as-is.
+      </p>
+
+      <p>
+        Consider <a href="#quoted-example" class="box-ref">Example<bdi> 6</bdi></a> reformatted using the <code>$</code>-<a href="#dfn-convenience-context" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-convenience-context-1">convenience context</a>:</p>
+
+        <div class="example" id="example-example-yaml-ld-document-with-convenience-context">
+        <div class="marker">
+    <a class="self-link" href="#example-example-yaml-ld-document-with-convenience-context">Example<bdi> 7</bdi></a><span class="example-title">: Example YAML-LD document with Convenience Context</span>
+  </div> <pre class="json" data-format="application/ld+json" aria-busy="false"><code class="hljs">"@context":
+  - https://json-ld.org/contexts/dollar-convenience.jsonld
+  - https://schema.org
+
+$id: https://w3.org/yaml-ld/
+$type: WebContent</code></pre>
+      </div>
+  </section>
+
+  <section id="comments-as-whitespace" class="informative"><div class="header-wrapper"><h2 id="c-why-are-comments-treated-as-whitespace"><bdi class="secno">C. </bdi>Why are comments treated as whitespace?</h2><a class="self-link" href="#comments-as-whitespace" aria-label="Permalink for Section C."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <section id="consistency"><div class="header-wrapper"><h3 id="c-1-consistency"><bdi class="secno">C.1 </bdi>Consistency</h3><a class="self-link" href="#consistency" aria-label="Permalink for Section C.1"></a></div>
+      
+
+      <dl>
+        <dt>[<cite><a class="bibref" data-link-type="biblio" href="#bib-turtle" title="RDF 1.1 Turtle">TURTLE</a></cite>] and other Linked Data serializations which support comments</dt>
+        <dd>do not provide a means to preserve them
+          when processing and serializing the document
+          in other formats
+        </dd>
+
+        <dt>YAML</dt>
+        <dd>
+          requires that parts of the document not reflected by
+
+          <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">representation graph</a>, such as
+
+          <ul>
+            <li>comments</li>
+            <li>directives</li>
+            <li>mapping key order</li>
+            <li>anchor names</li>
+          </ul>
+
+          must not be used to convey application level information
+        </dd>
+      </dl>
+    </section>
+
+    <section id="predictability"><div class="header-wrapper"><h3 id="c-2-predictability"><bdi class="secno">C.2 </bdi>Predictability</h3><a class="self-link" href="#predictability" aria-label="Permalink for Section C.2"></a></div>
+      
+
+      <p>
+        Theoretically, we could try harvesting YAML comments into
+        JSON-LD documents. We would define a specific predicate, like
+        <code>https://json-ld.org/yaml-ld/comment</code>, and convert
+        every <code># My comment</code> fragment into a
+        <code>{"yaml-ld:comment": "My comment"}</code> piece of the JSON-LD
+        document.
+      </p>
+
+      <p>
+        This would, however, have the following impacts on 
+        implementations:
+      </p>
+
+      <ul>
+        <li>
+          They would be more complicated, because most industrially 
+          available YAML parsers discard comments on reading YAML data
+        </li>
+        <li>
+          They would be less predictable, because order of keys is not
+          preserved in JSON — and therefore, when converting a JSON-LD
+          document back to YAML-LD, comments might be displaced.
+        </li>
+      </ul>
+    </section>
+  </section>
+
+  <section id="streams" class="informative"><div class="header-wrapper"><h2 id="d-streams"><bdi class="secno">D. </bdi>Streams</h2><a class="self-link" href="#streams" aria-label="Permalink for Section D."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>
+      Every YAML-LD file is a <a href="#dfn-yaml-ld-stream" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-stream-1">YAML-LD stream</a>
+      and might contain multiple <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-11">YAML-LD documents</a>,
+      as shown in the example below.
+    </p>
+
+    <div class="example" id="example-yaml-ld-with-several-documents-in-one-file">
+        <div class="marker">
+    <a class="self-link" href="#example-yaml-ld-with-several-documents-in-one-file">Example<bdi> 8</bdi></a><span class="example-title">: YAML-LD with several documents in one file</span>
+  </div> <pre class="yaml" data-result-for="YAML-LD with multiple documents" data-content-type="application/ld+json" aria-busy="false"><code class="hljs">"@context": https://schema.org
+"@id": https://w3.org/yaml-ld/
+"@type": WebContent
+name: YAML-LD
+---
+"@context": https://schema.org
+"@id": https://www.w3.org/TR/json-ld11/
+"@type": WebContent
+name: JSON-LD</code></pre>
+      </div>
+
+    <div class="issue" id="issue-container-number-63"><div role="heading" class="issue-title marker" id="h-issue" aria-level="3"><a href="https://github.com/json-ld/yaml-ld/issues/63"><span class="issue-number">Issue 63</span></a><span class="issue-label">: YAML Streams and JSON Sequences <a class="respec-gh-label" href="https://github.com/json-ld/yaml-ld/issues/?q=is%3Aissue+is%3Aopen+label%3A%22spec%22" style="background-color: rgb(203, 83, 188); color: rgb(0, 0, 0);" aria-label="GitHub label: spec">spec</a></span></div><p class="">
+      <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML streams</a> may correspond more directly to
+      <cite><a data-matched-text="[[[RFC7464]]]" href="https://www.rfc-editor.org/rfc/rfc7464">JavaScript Object Notation (JSON) Text Sequences</a></cite>, which are not presently part of the
+      <a href="https://www.w3.org/TR/json-ld11/#dfn-internal-representation">JSON-LD internal representation</a>.
+      The description here more closely aligns with how JSON-LD
+      interprets <a href="https://www.w3.org/TR/json-ld11-api/#html-content-algorithms">HTML Scripts</a>.
+    </p></div>
+
+    <p>
+      Current specification does not support this feature.
+      Implementations <em class="rfc2119">MAY</em> choose, for example, to do any of the following:
+    </p>
+
+    <ul>
+      <li>Convert each document into a separate JSON-LD document</li>
+      <li>Convert the whole YAML-LD stream into a single JSON-LD array</li>
+    </ul>
+
+    <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note" aria-level="3"><span>Note</span><span class="issue-label">: Interoperability considerations on YAML streams</span></div><p class="">
+      For interoperability considerations on YAML streams,
+      see <a href="https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html#section-3.2">the relevant section in YAML Media Type</a>.
+    </p></div>
+  </section>
+
+    <section id="extended-profile" class="informative"><div class="header-wrapper"><h2 id="e-extended-yaml-ld-profile"><bdi class="secno">E. </bdi>Extended YAML-LD Profile</h2><a class="self-link" href="#extended-profile" aria-label="Permalink for Section E."></a></div><p><em>This section is non-normative.</em></p>
+      
+
+      <section id="motivation"><div class="header-wrapper"><h3 id="e-1-motivation"><bdi class="secno">E.1 </bdi>Motivation</h3><a class="self-link" href="#motivation" aria-label="Permalink for Section E.1"></a></div>
+        
+
+        <p>
+          The YAML-LD specification relies upon YAML to serialize Linked Data to the extent
+          that YAML is compatible with JSON, which simplifies the operation and usage
+          of YAML-LD. However, the <a href="#json-vs-yaml">more
+          expressive feature set</a> of YAML invites us to represent
+          Linked Data in a more expressive way.
+        </p>
+
+        <p>
+          In the cases described above, one of the possible expressive methods is a
+          specific feature of YAML language. To leverage those methods, we propose an
+          <strong>Extended YAML-LD Profile</strong> which will implement all such features.
+        </p>
+
+        <div class="note" id="issue-container-generatedID-4"><div role="heading" class="ednote-title marker" id="h-ednote-3" aria-level="4"><span>Editor's note</span></div><div class="">
+          The Extended Profile is out of scope for the normative part
+          of this specification; we leave it for later versions,
+          pending feedback from the community and new knowledge gained
+          from practical experience of using the basic version
+          of YAML-LD that we will henceforth call
+          <strong>Basic Profile of YAML-LD</strong>.
+        </div></div>
+
+        <section id="specify-node-type"><div class="header-wrapper"><h4 id="e-1-1-specify-node-type"><bdi class="secno">E.1.1 </bdi>Specify node <code>@type</code></h4><a class="self-link" href="#specify-node-type" aria-label="Permalink for Section E.1.1"></a></div>
+          
+
+          <p>
+            When converting JSON-LD to RDF, <code>@type</code> translates to
+            one of the following:
+          </p>
+
+          <ul>
+            <li>an <code>rdf:type</code> edge</li>
+            <li>a <code>datatype</code> mark for a <code>Literal</code> node</li>
+          </ul>
+
+          <p>Possible ways to specify this in YAML-LD are the following:</p>
+
+          <ul>
+            <li>
+              In the <code>@context</code>, but there we can only say that the node is an IRI,
+              we cannot specify a particular <code>rdf:type</code>
+            </li>
+            <li>
+              Using [<cite><a class="bibref" data-link-type="biblio" href="#bib-rdf-schema" title="RDF Schema 1.1">RDF-SCHEMA</a></cite>] and [<cite><a class="bibref" data-link-type="biblio" href="#bib-owl2-syntax" title="OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)">OWL2-SYNTAX</a></cite>] based logical reasoning, for instance, via
+              <code>rdfs:domain</code> or <code>rdfs:range</code> properties
+            </li>
+            <li>Inline, using the <code>@type</code> keyword</li>
+            <li>
+              <p>Using a YAML Tag, as shown below:</p>
+              <div class="example" id="example-yaml-ld-with-tags">
+        <div class="marker">
+    <a class="self-link" href="#example-yaml-ld-with-tags">Example<bdi> 9</bdi></a><span class="example-title">: YAML-LD with tags</span>
+  </div> <pre class="yaml" data-result-for="YAML-LD: Tags" data-content-type="application/ld+json" aria-busy="false"><code class="hljs">%TAG !xsd! http://www.w3.org/2001/XMLSchema%23
+---
+"@context": https://schema.org
+"@id": https://w3.org/yaml-ld/
+dateModified: !xsd:date 2023-06-26</code></pre>
+      </div>
+
+              <p>
+                Here, <code>%TAG</code> declares the <code>!xsd:</code> prefix for tags used
+                in the document. YAML treats tags as IRIs, which brings it close to the LD family
+                of data formats. Note that the directives section must be separated
+                from the main document with <code>---</code> (a line containing exactly three hyphens).
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section id="reduce-duplication"><div class="header-wrapper"><h4 id="e-1-2-reduce-duplication"><bdi class="secno">E.1.2 </bdi>Reduce duplication</h4><a class="self-link" href="#reduce-duplication" aria-label="Permalink for Section E.1.2"></a></div>
+          
+
+          <p>
+            If a segment of a YAML document has to be repeated more than once, one of the
+            following approaches can be taken:
+          </p>
+
+          <ul>
+            <li>Repeat the segment as many times as necessary</li>
+            <li>
+              If the segment represents a node, designate it once
+              with a YAML-LD <code>@id</code>, and then address it by the given identifier
+            </li>
+            <li>
+              <p>
+                Use YAML <a href="https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases">anchors &amp; aliases</a>
+                as shown in <a href="#example-with-anchors" class="box-ref">Example<bdi> 4</bdi></a>.
+              </p>
+            </li>
+          </ul>
+        </section>
+      </section>
+
+      <section id="approaches"><div class="header-wrapper"><h3 id="e-2-approaches"><bdi class="secno">E.2 </bdi>Approaches</h3><a class="self-link" href="#approaches" aria-label="Permalink for Section E.2"></a></div>
+        
+
+        <p>
+          Two alternative approaches have been proposed to implement the Extended profile:
+        </p>
+
+        <ul>
+          <li>Extended Internal Representation</li>
+          <li>
+            Preprocessor to convert an Extended YAML-LD document
+            to a plain YAML-LD document
+          </li>
+        </ul>
+      </section>
+
+      <section id="extended-internal-representation-0"><div class="header-wrapper"><h3 id="e-3-extended-internal-representation"><bdi class="secno">E.3 </bdi>Extended Internal Representation</h3><a class="self-link" href="#extended-internal-representation-0" aria-label="Permalink for Section E.3"></a></div>
+        
+
+        <p>
+          This approach implies extending the
+          <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">JSON-LD internal representation</a> to allow a more complete expression
+          of native data types within YAML-LD, and allows use of the complete
+          <cite><a data-matched-text="[[[JSON-LD11-API]]]" href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 Processing Algorithms and API</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>]
+          <a href="https://www.w3.org/TR/json-ld11-api/#the-application-programming-interface">
+            Application Programming Interface
+          </a>
+          to manipulate extended YAML-LD documents.
+        </p>
+
+        <p>
+          A <a href="#dfn-yaml-ld-document" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-document-12">YAML-LD document</a> complies with
+          the <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-1">YAML-LD extended profile</a> of this specification
+          if it follows the normative statements from this specification
+          and can be transformed into the
+          <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-1">JSON-LD extended internal representation</a>,
+          then back to a conforming YAML-LD document,
+          without loss of semantic information.
+        </p>
+
+        <p id="cr-well-formed" data-tests="
+        manifest.html#cr-well-formed-1-positive,
+        manifest.html#cr-well-formed-2-negative,
+        manifest.html#cr-well-formed-3-negative">
+          As [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>] has well-defined representation requirements,
+          all YAML-LD streams <em class="rfc2119">MUST</em> form a
+          <a href="https://yaml.org/spec/1.2.2/#well-formed-streams-and-identified-aliases">
+            well-formed stream
+          </a>
+          and use <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias node</a> defined by a previous <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a>
+          with a corresponding <a data-lt="node anchor" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">anchor</a>;
+          otherwise, a
+          <a href="https://www.w3.org/TR/json-ld11-api/#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
+          error has been detected and processing is aborted.
+        </p>
+
+        <p>
+          The <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-2">YAML-LD extended profile</a> allows full use of
+          <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">anchor names</a> and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias nodes</a> subject to
+          the requirements described above in this section.
+        </p>
+
+        <p id="cir-extended" data-tests="">
+          If the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-1"><code>extendedYAML</code></a> API flag is <code>true</code>, the processing result
+          will be in the <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-2">extended internal representation</a>.
+        </p>
+
+        <p id="aa-json-aliases" data-tests="manifest.html#aa-cycles-1-positive">
+          When processing using the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-2">YAML-LD Basic profile</a>,
+          documents <em class="rfc2119">MUST NOT</em> contain <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias nodes</a>;
+          otherwise, a
+          <a href="#dom-yamllderrorcode-profile-error" class="internalDFN" data-link-type="idl" id="ref-for-dom-yamllderrorcode-profile-error-1"><code>profile-error</code></a>
+          error has been detected and processing is aborted.
+        </p>
+
+
+        <section id="conversion-to-ir"><div class="header-wrapper"><h4 id="e-3-1-conversion-to-the-internal-representation"><bdi class="secno">E.3.1 </bdi>Conversion to the Internal Representation</h4><a class="self-link" href="#conversion-to-ir" aria-label="Permalink for Section E.3.1"></a></div>
+          
+
+          <p>YAML-LD processing is defined by converting YAML to the
+            <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a> and using <cite><a data-matched-text="[[[JSON-LD11-API]]]" href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 Processing Algorithms and API</a></cite>
+            to process on that representation,
+            after which the representation is converted back to YAML.
+            As information specific to a given <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a> structure is lost
+            in this transformation, much of the specifics of that
+            original representation are therefore lost in that conversion,
+            limiting the ability to fully round-trip a YAML-LD document back
+            to an equivalent representation.
+            Consequently, round-tripping in this context is limited to preservation of the semantic
+            representation of a document,
+            rather than a specific syntactic representation.</p>
+
+          <aside class="example" id="example-yaml-sequences"><div class="marker">
+    <a class="self-link" href="#example-yaml-sequences">Example<bdi> 10</bdi></a><span class="example-title">: YAML Sequences</span>
+  </div>
+            <p>For example, YAML has multiple ways to encode an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>,
+              YAML <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-sequences">block sequences</a> and
+              <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-sequences">flow sequences</a>.
+              Both forms describe the same <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a> of two <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">strings</a>.</p>
+
+            <p>A YAML <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-sequences">block sequence</a>:</p>
+            <pre data-content-type="application/yaml" aria-busy="false"><code class="hljs">- one
+- two</code></pre>
+
+            <p>A YAML <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-sequences">flow sequence</a>:</p>
+            <pre data-content-type="application/yaml" aria-busy="false"><code class="hljs json">[one, two]</code></pre>
+          </aside>
+
+          <p>The conversion process represented here is compatible with
+            the description of
+            "Composing the Representation Graph" from the
+            <a href="https://yaml.org/spec/1.2.2/#load">3.1.2 Load</a> section of [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>].
+            The steps described below for converting to the
+            <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a> operate upon that
+            <a href="https://yaml.org/spec/1.2.2/#representation-graph">YAML Ain’t Markup Language (YAML™) version 1.2.2</a>.
+          </p>
+
+          <p>When operating using the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-3">YAML-LD Basic profile</a>,
+            it is intended that the common feature provided by most
+            YAML libraries of transforming YAML directly to JSON
+            satisfies the requirements for parsing a YAML-LD file.
+          </p>
+
+          <div class="issue" id="issue-container-number-12"><div role="heading" class="issue-title marker" id="h-issue-0" aria-level="5"><a href="https://github.com/json-ld/yaml-ld/issues/12"><span class="issue-number">Issue 12</span></a><span class="issue-label">: Convert JSON-LD to YAML-LD using standard YAML libraries <a class="respec-gh-label" href="https://github.com/json-ld/yaml-ld/issues/?q=is%3Aissue+is%3Aopen+label%3A%22UCR%22" style="background-color: rgb(233, 150, 149); color: rgb(0, 0, 0);" aria-label="GitHub label: UCR">UCR</a></span></div><p class="">
+            As a developer,
+            I want to be able to convert JSON-LD documents to YAML-LD by simply serializing the document using any
+            standard YAML library,
+            So that the resulting YAML is valid YAML-LD, resolving to the same graph as the original JSON-LD.
+          </p></div>
+
+          <section id="convert-stream" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-1-converting-a-yaml-stream"><bdi class="secno">E.3.1.1 </bdi>Converting a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a></h5><a class="self-link" href="#convert-stream" aria-label="Permalink for Section E.3.1.1"></a></div>
+            
+
+            <p>A <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a> is composed of zero or more <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML documents</a>.</p>
+
+            <ol>
+              <li>Set <var>stream content</var> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>.</li>
+              <li>If the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">stream</a> is empty,
+                set <var>stream content</var> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>.
+              </li>
+              <li>Otherwise, if the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">stream</a> contains a single <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a>,
+                set <var>stream content</var> the result of
+                <a href="#convert-document" class="sectionRef sec-ref"><bdi class="secno">E.3.1.2 </bdi>Converting a <span>YAML document</span></a>.
+              </li>
+              <li>Otherwise: for each <var>document</var> in the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">stream</a>:
+                <ol>
+                  <li>Set <var>doc</var> to the result of <a href="#convert-document" class="sectionRef sec-ref"><bdi class="secno">E.3.1.2 </bdi>Converting a <span>YAML document</span></a> for <var>document</var>.</li>
+                  <li>If <var>doc</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>,
+                    merge it to the end of <var>stream content</var>.
+                  </li>
+                  <li>Otherwise, append <var>doc</var> to <var>stream content</var></li>
+                </ol>
+                <div class="note" id="issue-container-generatedID-5"><div role="heading" class="ednote-title marker" id="h-ednote-4" aria-level="6"><span>Editor's note</span></div><div class="">
+                  This step is inconsistent with other statements about processing each
+                  document separately, resulting in some other stream of JSON-LD output
+                  (i.e., something like <em>NDJSOND-LD</em>).
+                  Also, presumably an empty stream would result in either
+                  an empty <em>NDJSON-LD</em> document, or an empty [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld" title="JSON-LD 1.0">JSON-LD</a></cite>] document.
+                </div></div>
+              </li>
+              <li>The conversion result is <var>stream content</var>.</li>
+            </ol>
+
+            <p id="cir-stream" data-tests="
+          manifest.html#cr-utf8-2-negative,
+          manifest.html#cr-well-formed-2-negative,
+          manifest.html#aa-cycles-2-negative,
+          manifest.html#cr-well-formed-3-negative">
+              Any error reported in a recursive processing step <em class="rfc2119">MUST</em> result
+              in the failure of this processing step.</p>
+          </section>
+
+          <section id="convert-document" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-2-converting-a-yaml-document"><bdi class="secno">E.3.1.2 </bdi>Converting a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a></h5><a class="self-link" href="#convert-document" aria-label="Permalink for Section E.3.1.2"></a></div>
+            
+
+            <p>From the <a href="https://yaml.org/spec/1.2.2/#">YAML grammar</a>,
+              a YAML document <em class="rfc2119">MAY</em> be preceded by a
+              <a href="https://yaml.org/spec/1.2.2/#rule-l-document-prefix">Document Prefix</a>
+              and/or a set of
+              <a href="https://yaml.org/spec/1.2.2/#rule-l-directive">directives</a>
+              followed by a
+              <a href="https://yaml.org/spec/1.2.2/#rule-l-bare-document">YAML bare document</a>,
+              which is composed of a single <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a>.
+            </p>
+
+            <ol>
+              <li>Create an empty <var>named nodes</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+                which will be used to associate each <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias node</a>
+                with the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a>
+                having the corresponding <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">node anchor</a>.
+              </li>
+              <li id="cir-document-content" data-tests="manifest.html#cir-document-content-1-negative">
+                Set <var>document content</var> to the result
+                of processing the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> associated with the
+                <a href="https://yaml.org/spec/1.2.2/#rule-l-bare-document">YAML bare document</a>,
+                using the appropriate conversion step defined in this section.
+                If that <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> is not one of the following, a
+                <a href="https://www.w3.org/TR/json-ld11-api/#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
+                error has been detected and processing is aborted.
+
+                <ul>
+                  <li><a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-sequences">block sequence</a>,</li>
+                  <li><a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-mappings">block mapping</a>, or</li>
+                  <li><a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-sequences">flow sequence</a>,</li>
+                  <li><a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-mappings">flow mapping</a>, or</li>
+                </ul>
+
+                <div class="note" role="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-0" aria-level="6"><span>Note</span></div><div class="">
+                  A <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> may be of another type, but this is incompatilbe
+                  with JSON-LD, where the top-most node must be either an
+                  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a> or <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>.
+                </div></div>
+              </li>
+              <li>The conversion result is <var>document content</var>.</li>
+            </ol>
+
+            <p id="cir-document" data-tests="
+          manifest.html#cr-utf8-2-negative,
+          manifest.html#cr-well-formed-2-negative,
+          manifest.html#aa-cycles-2-negative,
+          manifest.html#cr-well-formed-3-negative">
+              Any error reported in a recursive processing step <em class="rfc2119">MUST</em> result
+              in the failure of this processing step.</p>
+          </section>
+
+          <section id="convert-seq" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-3-converting-a-yaml-sequence"><bdi class="secno">E.3.1.3 </bdi>Converting a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">YAML sequence</a></h5><a class="self-link" href="#convert-seq" aria-label="Permalink for Section E.3.1.3"></a></div>
+            
+
+            <p>Both <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-sequences">block sequences</a> and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-sequences">flow sequences</a>
+              are directly aligned with
+              an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a> in the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>.</p>
+
+            <ol>
+              <li>Set <var>sequence content</var> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>.</li>
+              <li>If the <a data-lt="YAML sequence" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">sequence</a> has a
+                <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">node anchor</a>,
+                add a reference from the anchor name to the
+                <a data-lt="YAML sequence" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">sequence</a>
+                in the <var>named nodes</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>.
+              </li>
+              <li>For each <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> <var>n</var> in the
+                <a data-lt="YAML sequence" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">sequence</a>,
+                append the result of processing <var>n</var>
+                to <var>sequence content</var>
+                using the appropriate conversion step.
+              </li>
+              <li>The conversion result is <var>sequence content</var>.</li>
+            </ol>
+
+            <p id="cir-seq">
+              Any error reported in a recursive processing step <em class="rfc2119">MUST</em> result
+              in the failure of this processing step.</p>
+          </section>
+
+          <section id="convert-mapping" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-4-converting-a-yaml-mapping"><bdi class="secno">E.3.1.4 </bdi>Converting a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a></h5><a class="self-link" href="#convert-mapping" aria-label="Permalink for Section E.3.1.4"></a></div>
+            
+
+            <p>Both <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#block-mappings">block mappings</a> and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#flow-mappings">flow mappings</a>
+              are directly aligned with
+              a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> in the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>.</p>
+
+            <ol>
+              <li>Set <var>mapping content</var> to an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>.</li>
+              <li>Otherwise, if the <a data-lt="YAML mapping" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">mapping</a> has a
+                <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">node anchor</a>,
+                add a reference from the anchor name to
+                the <a data-lt="YAML mapping" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">mapping</a>
+                in the <var>named nodes</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>.
+              </li>
+              <li>For each <var>entry</var> in the <a data-lt="YAML mapping" data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">mapping</a>
+                composed of a key/value pair:
+                <ol>
+                  <li>Set <var>key</var> and <var>value</var>
+                    to the result of processing <var>entry</var>
+                    using the appropriate conversion step.
+                  </li>
+                  <li id="cir-mapping-key" data-tests="manifest.html#cir-mapping-key-1-negative">
+                    If <var>key</var> is not a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">string</a>,
+                    a <a href="#dom-yamllderrorcode-mapping-key-error" class="internalDFN" data-link-type="idl" id="ref-for-dom-yamllderrorcode-mapping-key-error-1"><code>mapping-key-error</code></a>
+                    error has been detected and processing <em class="rfc2119">MUST</em> be aborted.
+                  </li>
+                  <li>Add a new <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entry</a> to
+                    <var>mapping content</var> using
+                    <var>key</var> and <var>value</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>The conversion result is <var>mapping content</var>.</li>
+            </ol>
+
+            <p id="cir-mapping" data-tests="
+          manifest.html#cr-utf8-2-negative,
+          manifest.html#cr-well-formed-2-negative,
+          manifest.html#aa-cycles-2-negative,
+          manifest.html#cr-well-formed-3-negative">
+              Any error reported in a recursive processing step <em class="rfc2119">MUST</em> result
+              in the failure of this processing step.</p>
+          </section>
+
+          <section id="convert-scalar" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-5-converting-a-yaml-scalar"><bdi class="secno">E.3.1.5 </bdi>Converting a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a></h5><a class="self-link" href="#convert-scalar" aria-label="Permalink for Section E.3.1.5"></a></div>
+            
+
+            <ol>
+              <li>If the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-2"><code>extendedYAML</code></a> flag is <code>true</code>,
+                and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> <var>n</var>
+                has a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tag</a> <var>t</var>,
+                <var>n</var> is mapped as follows:
+                <ol>
+                  <li id="cir-scalar-core" data-tests="
+                manifest.html#cir-scalar-core-1-positive,
+                manifest.html#cir-scalar-core-2-positive">
+                    If <var>t</var> resolves with a prefix of <code>tag:yaml.org.2002:</code>,
+                    the conversion result is mapped through the
+                    <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>.
+                  </li>
+                  <li id="cir-scalar-i18n">
+                    Otherwise, if <var>t</var> resolves with a prefix of <code>https://www.w3.org/ns/i18n#</code>,
+                    and the suffix <strong>does not</strong> contain
+                    an underscore (<code>"_"</code>),
+                    the conversion result is a <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged string</a>
+                    with value taken from <var>n</var>,
+                    and a <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> taken from the suffix of <var>t</var>.
+                    <div class="note" role="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-1" aria-level="6"><span>Note</span></div><div class="">
+                      <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">Node tags</a> including an underscore (<code>"_"</code>),
+                      such as <code>i18n:ar-eg_rtl</code> describe a combination
+                      of language and text direction.
+                      See <a href="https://www.w3.org/TR/json-ld11/#the-i18n-namespace">
+                      The <code>i18n</code> Namespace
+                    </a>
+                      in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>].
+                    </div></div>
+                  </li>
+                  <li id="cir-scalar-other" data-tests="
+                manifest.html#cir-scalar-other-1-positive,
+                manifest.html#cir-scalar-other-2-positive">
+                    Otherwise, the conversion result is an
+                    <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a> with value taken from <var>n</var>
+                    and <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a> taken from <var>t</var>.
+                  </li>
+                </ol>
+              </li>
+              <li id="cir-scalar-json" data-tests="
+            manifest.html#cir-scalar-core-1-positive,
+            manifest.html#cir-scalar-i18n-1-positive,
+            manifest.html#cir-scalar-other-1-positive">
+                Otherwise, the conversion result is mapped through the
+                <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>.
+              </li>
+            </ol>
+
+            <div class="note" role="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-2" aria-level="6"><span>Note</span></div><p class="">
+              Implementations may retain the
+              representation as an <a href="https://yaml.org/spec/1.2.2/#integer">YAML Integer</a>,
+              or <a href="https://yaml.org/spec/1.2.2/#floating-point">YAML Floating Point</a>,
+              but a JSON-LD processor must treat them uniformly
+              as a <a data-link-type="dfn" href="https://tc39.es/ecma262/multipage/#sec-terms-and-definitions-number-value">number</a>, although the specific type of number
+              value <em class="rfc2119">SHOULD</em> be retained for round-tripping.
+            </p></div>
+          </section>
+
+          <section id="convert-alias" class="algorithm"><div class="header-wrapper"><h5 id="e-3-1-6-converting-a-yaml-alias-node"><bdi class="secno">E.3.1.6 </bdi>Converting a YAML <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias node</a></h5><a class="self-link" href="#convert-alias" aria-label="Permalink for Section E.3.1.6"></a></div>
+            
+
+            <p>
+              The conversion result is the value of the entry
+              in the <var>named nodes</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a> having the <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">node</a> entry.
+              If none exist, the document is invalid,
+              and processing <em class="rfc2119">MUST</em> end in failure.
+            </p>
+
+            <p id="cir-alias-json" data-tests="
+          manifest.html#cr-well-formed-1-positive,
+          manifest.html#cr-well-formed-2-negative">
+              If an <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias node</a> is encountered when processing the
+              <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">YAML representation graph</a>
+              and the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-3"><code>extendedYAML</code></a> flag is <code>false</code>,
+              the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-4">YAML-LD Basic profile</a> has been selected.
+              A <a href="#dom-yamllderrorcode-profile-error" class="internalDFN" data-link-type="idl" id="ref-for-dom-yamllderrorcode-profile-error-2"><code>profile-error</code></a>
+              error has been detected and processing <em class="rfc2119">MUST</em> be aborted.
+            </p>
+
+            <p id="cir-alias-cycles" data-tests="
+          manifest.html#aa-cycles-1-positive,
+          manifest.html#aa-cycles-2-negative,
+          manifest.html#aa-cycles-3-positive">
+              If a cycle is detected,
+              a processing error <em class="rfc2119">MUST</em> be returned,
+              and processing aborted.
+            </p>
+          </section>
+        </section>
+
+        <section id="conversion-to-yaml"><div class="header-wrapper"><h4 id="e-3-2-conversion-to-yaml"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</h4><a class="self-link" href="#conversion-to-yaml" aria-label="Permalink for Section E.3.2"></a></div>
+          
+
+          <p>The conversion process from the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+            involves turning that representation back into a YAML
+            <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">representation graph</a>
+            and relies on the description of
+            "Serializing the Representation Graph" from the
+            <a href="https://yaml.org/spec/1.2.2/#dump">3.1.1 Dump</a> section of [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>]
+            for the final serialization.
+          </p>
+
+          <p>
+            As the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a> is rooted by either
+            an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a> or a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
+            the process of transforming the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+            to YAML begins by preparing an empty <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">representation graph</a>
+            which will be rooted with either a
+            <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a> or <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">YAML sequence</a>.
+          </p>
+
+          <p>
+            Although outside of the scope of this specification,
+            processors <em class="rfc2119">MAY</em> use
+            <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#directives">YAML directives</a>, including <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#tag-directives">TAG directives</a>, and
+            <a href="https://yaml.org/spec/1.2.2/#document-markers">Document markers</a>,
+            as appropriate for best results.
+            Specifically, if the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-4"><code>extendedYAML</code></a> API flag is <code>true</code>,
+            the document <em class="rfc2119">SHOULD</em> use the <code>%YAML</code> directive with
+            version set to at least <code>1.2</code>.
+            To improve readability and reduce document size,
+            the document <em class="rfc2119">MAY</em> use a <code>%TAG</code> directive appropriate for
+            <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a> contained within the representation.
+          </p>
+
+          <div class="note" role="note" id="issue-container-generatedID-9"><div role="heading" class="note-title marker" id="h-note-3" aria-level="5"><span>Note</span></div><p class="">
+            The use of <code>%TAG</code> directives in YAML-LD is similar to the use
+            of the <code>PREFIX</code> directive in [<cite><a class="bibref" data-link-type="biblio" href="#bib-turtle" title="RDF 1.1 Turtle">Turtle</a></cite>]
+            or the general use of terms as prefixes to create
+            <a href="https://www.w3.org/TR/json-ld11/#dfn-compact-iri">Compact IRIs</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>]:
+            they not change the meaning of the encoded scalars.
+          </p></div>
+
+          
+
+          <div class="example" id="example-serialized-representation-of-the-extended-internal-representation">
+        <div class="marker">
+    <a class="self-link" href="#example-serialized-representation-of-the-extended-internal-representation">Example<bdi> 11</bdi></a><span class="example-title">: Serialized representation of the extended internal representation</span>
+  </div> <pre class="yaml" data-result-for="YAML-LD with multiple documents" data-content-type="application/ld+json" aria-busy="false"><code class="hljs">%TAG !xsd! http://www.w3.org/2001/XMLSchema%23
+---
+"@context": https://schema.org
+"@id": https://github.com/gkellogg
+"@type": Person
+name: !xsd!string Gregg Kellogg
+birthDate: !xsd!date 1970-01-01</code></pre>
+      </div>
+
+          <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-4" aria-level="5"><span>Note</span></div><p class="">
+            Although allowed within the YAML Grammar, some current YAML parsers
+            do not allow the use of <code>"#"</code> within a tag URI. Substituting
+            the <code>"%23"</code> escape is a workaround for this problem, that will
+            hopefully become unnecessary as implementations are updated.
+          </p></div>
+
+          <div class="issue" id="issue-container-number-6"><div role="heading" class="issue-title marker" id="h-issue-1" aria-level="5"><a href="https://github.com/json-ld/yaml-ld/issues/6"><span class="issue-number">Issue 6</span></a><span class="issue-label">: Use tags to distinguish "plain" YAML-LD from "idiomatic" YAML-LD <a class="respec-gh-label" href="https://github.com/json-ld/yaml-ld/issues/?q=is%3Aissue+is%3Aopen+label%3A%22UCR%22" style="background-color: rgb(233, 150, 149); color: rgb(0, 0, 0);" aria-label="GitHub label: UCR">UCR</a><a class="respec-gh-label" href="https://github.com/json-ld/yaml-ld/issues/?q=is%3Aissue+is%3Aopen+label%3A%22spec%22" style="background-color: rgb(203, 83, 188); color: rgb(0, 0, 0);" aria-label="GitHub label: spec">spec</a></span></div><div class="markdown">
+            <p>A concrete proposal in that direction would be to use a tag at the
+              top-level of any "idiomatic" YAML-LD document, applying to the whole
+              object/array that makes the document.</p>
+
+            <p>It might also include a version
+              to identify the specification that it relates to, allowing
+              for version announcement that could be used for future-proofing.</p>
+
+            <p>The following block is one example:</p>
+
+            <pre aria-busy="false"><code class="hljs javascript">!yaml-ld
+<span class="hljs-attr">$context</span>: http:<span class="hljs-comment">//schema.org</span>
+$type: Person
+<span class="hljs-attr">name</span>: Pierre-Antoine Champin</code></pre>
+          </div></div>
+
+          <p>See <a href="#example-serialized-representation-of-the-extended-internal-representation" class="box-ref">Example<bdi> 11</bdi></a> for an example
+            of serializing the extended internal representation.</p>
+
+          <section id="convert-ir" class="algorithm"><div class="header-wrapper"><h5 id="e-3-2-1-converting-from-the-internal-representation"><bdi class="secno">E.3.2.1 </bdi>Converting From the Internal Representation</h5><a class="self-link" href="#convert-ir" aria-label="Permalink for Section E.3.2.1"></a></div>
+            
+
+            <p>
+              This algorithm describes the steps to convert
+              each element from the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+              into corresponding <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#nodes">YAML nodes</a> by recursively
+              processing each element <var>n</var>.
+            </p>
+
+            <ol>
+              <li id="convert-array">
+                If <var>n</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">array</a>,
+                the conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#sequence">YAML sequence</a>
+                with child nodes of the sequence taken by converting
+                each value of <var>n</var> using this algorithm.
+              </li>
+              <li id="convert-map">
+                Otherwise, if <var>n</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
+                the conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a>
+                with keys and values taken by converting each
+                key/value pair of <var>n</var> using this algorithm.
+              </li>
+              <li id="convert-literal">
+                Otherwise, if <var>n</var> is an <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a>:
+                <ol>
+                  <li>
+                    If the <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a>
+                    of <var>n</var> is <code>xsd:string</code>,
+                    the conversion is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                    with the value taken from that value of <var>n</var>.
+                  </li>
+                  <li>Otherwise, if <var>n</var> is a <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged string</a>,
+                    the conversion is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                    with the value taken from that value of <var>n</var>
+                    and a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tag</a> constructed by appending
+                    that <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> to
+                    <code>https://www.w3.org/ns/i18n#</code>.
+                  </li>
+                  <li>
+                    Otherwise, the conversion is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                    with the value taken from that value of <var>n</var>
+                    and a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tag</a> taken from the
+                    <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a> of <var>n</var>.
+                  </li>
+                </ol>
+              </li>
+              <li id="convert-number">
+                Otherwise, if <var>n</var> is a <a data-link-type="dfn" href="https://tc39.es/ecma262/multipage/#sec-terms-and-definitions-number-value">number</a>,
+                the conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                with the value taken from <var>n</var>.
+              </li>
+              <li id="convert-boolean">
+                Otherwise, if <var>n</var> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean">boolean</a>,
+                the conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                with the value either <code>true</code> or <code>false</code>
+                based on the value of <var>n</var>.
+              </li>
+              <li id="convert-null">
+                Otherwise, if <var>n</var> is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#nulls">null</a>,
+                the conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                with the value <code>null</code>.
+              </li>
+              <li id="convert-string">
+                Otherwise, conversion result is a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a>
+                with the value taken from <var>n</var>.
+              </li>
+            </ol>
+          </section>
+        </section>
+
+        <section id="profiles"><div class="header-wrapper"><h4 id="e-3-3-application-profiles"><bdi class="secno">E.3.3 </bdi>Application Profiles</h4><a class="self-link" href="#profiles" aria-label="Permalink for Section E.3.3"></a></div>
+          
+
+          <p>This section identifies two application profiles for operating with
+            YAML-LD:</p>
+          <ul>
+            <li>the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-5">YAML-LD Basic profile</a>, and</li>
+            <li>the <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-3">YAML-LD Extended profile</a>.</li>
+          </ul>
+
+          <p>Application profiles allow publishers to use YAML-LD
+            either for maximum interoperability,
+            or for maximum expressivity.
+            The <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-6">YAML-LD Basic profile</a> provides for complete round-tripping
+            between YAML-LD documents and JSON-LD documents.
+            The <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-4">YAML-LD extended profile</a> allows for
+            fuller use of YAML features to enhance the ability to
+            represent a larger number of native datatypes
+            and reduce document redundancy.</p>
+
+
+          <p>Application profiles can be set using the <a data-link-type="idl" data-lt="JsonLdProcessor" data-type="interface" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor"><code>JsonLdProcessor</code></a>
+            API interface, as well as an HTTP request profile (see <a href="#iana" class="sectionRef sec-ref"><bdi class="secno">A. </bdi>IANA Considerations</a>).</p>
+
+          <section id="yaml-ld-json-profile"><div class="header-wrapper"><h5 id="e-3-3-1-yaml-ld-basic-profile"><bdi class="secno">E.3.3.1 </bdi>YAML-LD Basic Profile</h5><a class="self-link" href="#yaml-ld-json-profile" aria-label="Permalink for Section E.3.3.1"></a></div>
+            
+
+            <p>
+              The <dfn id="dfn-yaml-ld-basic-profile" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">YAML-LD Basic profile</dfn>
+              is based on the <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>,
+              which interprets only a limited set of <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a>.
+              <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalars</a> with <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a> outside of the defined range
+              <em class="rfc2119">SHOULD</em> be avoided and <em class="rfc2119">MUST</em> be converted to the closest
+              scalar type from the <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>,
+              if found.
+              See <a href="#convert-scalar" class="sectionRef sec-ref"><bdi class="secno">E.3.1.5 </bdi>Converting a <span>YAML scalar</span></a>
+              for specifics.
+            </p>
+
+            <p id="jp-utf8" data-tests="
+          manifest.html#cr-utf8-1-positive,
+          manifest.html#cr-utf8-2-negative">
+              Although YAML supports several additional encodings,
+              YAML-LD documents in the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-7">YAML-LD Basic Profile</a>
+              <em class="rfc2119">MUST NOT</em> use encodings other than UTF-8.
+            </p>
+
+            <p>
+              Keys used in a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a> <em class="rfc2119">MUST</em> be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">strings</a>.
+            </p>
+
+            <p>
+              Although YAML-LD documents <em class="rfc2119">MAY</em> include <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-anchors">node anchors</a>,
+              documents <em class="rfc2119">MUST NOT</em> use <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias nodes</a>.
+            </p>
+
+            <p>
+              A <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a> <em class="rfc2119">MUST</em> include only a single <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a>,
+              as the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">JSON-LD internal representation</a> only supports
+              a single document model.
+            </p>
+          </section>
+
+          <section id="yaml-ld-extended-profile"><div class="header-wrapper"><h5 id="e-3-3-2-yaml-ld-extended-profile"><bdi class="secno">E.3.3.2 </bdi>YAML-LD Extended Profile</h5><a class="self-link" href="#yaml-ld-extended-profile" aria-label="Permalink for Section E.3.3.2"></a></div>
+            
+
+            <p>
+              The <dfn id="dfn-yaml-ld-extended-profile" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">YAML-LD extended profile</dfn>
+              extends the <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>,
+              allowing <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a> to specify <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a>
+              by using a <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-3">JSON-LD extended internal representation</a> capable
+              of directly representing <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a>.
+            </p>
+
+            <p id="ep-utf8" data-tests="
+          manifest.html#cr-utf8-1-positive,
+          manifest.html#cr-utf8-2-negative">
+              As with the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-8">YAML-LD Basic profile</a>,
+              YAML-LD documents in the <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-5">YAML-LD extended profile</a>
+              <em class="rfc2119">MUST NOT</em> use encodings other than UTF-8.
+            </p>
+
+            <p>
+              As with the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-9">YAML-LD Basic profile</a>,
+              keys used in a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a> <em class="rfc2119">MUST</em> be <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">strings</a>.
+            </p>
+
+            <p>
+              YAML-LD docucments <em class="rfc2119">MAY</em> use <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#alias-nodes">alias nodes</a>,
+              as long as dereferencing these aliases does not result in a loop.
+            </p>
+
+            <p>
+              As with the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-10">YAML-LD Basic profile</a>,
+              a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML stream</a> <em class="rfc2119">MUST</em> include only a single <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">YAML document</a>,
+              as the <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-4">JSON-LD extended internal representation</a> only supports
+              a single document model.
+            </p>
+
+            <div class="issue" id="issue-container-number-79"><div role="heading" class="issue-title marker" id="h-issue-2" aria-level="6"><a href="https://github.com/json-ld/yaml-ld/issues/79"><span class="issue-number">Issue 79</span></a><span class="issue-label">: YAML-LD IRI tags</span></div><p class="">
+              Consier something like <code>!id</code> as a local tag to denote IRIs.
+            </p></div>
+
+            <section id="extended-internal-representation"><div class="header-wrapper"><h6 id="e-3-3-2-1-the-json-ld-extended-internal-representation"><bdi class="secno">E.3.3.2.1 </bdi>The JSON-LD Extended Internal Representation</h6><a class="self-link" href="#extended-internal-representation" aria-label="Permalink for Section E.3.3.2.1"></a></div>
+              
+
+              <p>
+                This specification defines
+                the <dfn data-lt="extended internal representation|JSON-LD extended internal representation" id="dfn-extended-internal-representation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">
+                JSON-LD extended internal representation
+              </dfn>, an extension
+                of the JSON-LD <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>.
+              </p>
+
+              <p>
+                In addition to <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map">maps</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list">arrays</a>, and <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">strings</a>,
+                the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a> allows native representation
+                of <a data-link-type="dfn" href="https://tc39.es/ecma262/multipage/#sec-terms-and-definitions-number-value">numbers</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean">boolean</a> values, and <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#nulls">nulls</a>.
+                The <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-5">extended internal representation</a> allows for native
+                representation of <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a>, both
+                with a <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a>,
+                and <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged strings</a>.
+              </p>
+
+              <p>
+                When transforming from the <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-6">extended internal representation</a>
+                to the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a> —
+                for example when serializing to JSON
+                or to the <a href="#dfn-yaml-ld-basic-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-basic-profile-11">YAML-LD Basic profile</a> —
+                implementations <em class="rfc2119">MUST</em> transform <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a> to the closest
+                native representation of the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>:
+              </p>
+
+              <ul>
+                <li>
+                  Literals with datatype
+                  <a href="https://www.w3.org/TR/xmlschema11-2/#boolean"><code>xsd:boolean</code></a>
+                  are transformed to either <code>true</code> or <code>false</code>,
+                </li>
+                <li>
+                  Literals with datatype
+                  <a href="https://www.w3.org/TR/xmlschema11-2/#decimal"><code>xsd:decimal</code></a>,
+                  <a href="https://www.w3.org/TR/xmlschema11-2/#decimal"><code>xsd:double</code></a>,
+                  <a href="https://www.w3.org/TR/xmlschema11-2/#decimal"><code>xsd:float</code></a>,
+                  or derived datatypes,
+                  are transformed to a native <a data-link-type="dfn" href="https://tc39.es/ecma262/multipage/#sec-terms-and-definitions-number-value">number</a>,
+                </li>
+                <li>
+                  All other literals are transformed to a native <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">string</a>.
+                </li>
+              </ul>
+
+              <div class="note" id="issue-container-generatedID-11"><div role="heading" class="ednote-title marker" id="h-ednote-5" aria-level="7"><span>Editor's note</span></div><p class="">
+                An alternative would be to transform such literals to
+                JSON-LD <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11/#dfn-value-object">value objects</a>,
+                and we may want to provide a means of transforming between
+                the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+                and <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-7">extended internal representation</a>
+                using <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11/#dfn-value-object">value objects</a>,
+                but this treatment is consistent with
+                [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>] <a href="https://yaml.org/spec/1.2.2/#core-schema">Core Schema</a>
+                <a href="https://yaml.org/spec/1.2.2/#1022-tag-resolution">Tag Resolution</a>.
+              </p></div>
+            </section>
+          </section>
+        </section>
+
+        <section id="api"><div class="header-wrapper"><h4 id="e-3-4-the-application-programming-interface"><bdi class="secno">E.3.4 </bdi>The Application Programming Interface</h4><a class="self-link" href="#api" aria-label="Permalink for Section E.3.4"></a></div>
+          
+
+          <p>
+            This specification extends the <cite><a data-matched-text="[[[JSON-LD11-API]]]" href="https://www.w3.org/TR/json-ld11-api/">JSON-LD 1.1 Processing Algorithms and API</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>]
+            <a href="https://www.w3.org/TR/json-ld11-api/#the-application-programming-interface">
+              Application Programming Interface
+            </a>
+            and the <cite><a data-matched-text="[[[JSON-LD11-FRAMING]]]" href="https://www.w3.org/TR/json-ld11-framing/">JSON-LD 1.1 Framing</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-framing" title="JSON-LD 1.1 Framing">JSON-LD11-FRAMING</a></cite>]
+            <a href="https://www.w3.org/TR/json-ld11-api/#the-application-programming-interface">
+              Application Programming Interface
+            </a>
+            to manage the serialization and deserialization of [<cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) version 1.2.2">YAML</a></cite>]
+            and to enable an option for setting the
+            <a href="#dfn-yaml-ld-extended-profile" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-yaml-ld-extended-profile-6">YAML-LD extended profile</a>.
+          </p>
+
+          <section id="jsonldprocessor"><div class="header-wrapper"><h5 id="e-3-4-1-jsonldprocessor"><bdi class="secno">E.3.4.1 </bdi>JsonLdProcessor</h5><a class="self-link" href="#jsonldprocessor" aria-label="Permalink for Section E.3.4.1"></a></div>
+            
+
+            <p>
+              The
+              <a href="https://www.w3.org/TR/json-ld11-api/#dfn-json-ld-processor">JSON-LD Processor</a>
+              interface is the high-level programming structure that developers
+              use to access the JSON-LD transformation methods.
+              The updates below is an experimental
+              extension of the <a data-link-type="idl" data-lt="JsonLdProcessor" data-type="interface" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor"><code>JsonLdProcessor</code></a> interface defined in the
+              JSON-LD 1.1 API [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>]
+              to serialize output as YAML rather than JSON.
+            </p>
+
+            <dl data-sort=""><dt><a data-link-type="idl" data-lt="compact()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-compact"><code>compact</code></a><code>()</code></dt>
+              <dd>
+                Updates step 10 of the <a data-link-type="idl" data-lt="compact()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-compact"><code>compact</code></a><code>()</code> algorithm
+                to serialize the the result as YAML rather than JSON
+                as defined in <a href="#conversion-to-yaml" class="sectionRef sec-ref"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a>.
+              </dd>
+              <dt><a data-link-type="idl" data-lt="expand()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-expand"><code>expand</code></a><code>()</code></dt>
+              <dd>
+                Updates step 9 of the <a data-link-type="idl" data-lt="expand()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-expand"><code>expand</code></a><code>()</code> algorithm
+                to serialize the the result as YAML rather than JSON
+                as defined in <a href="#conversion-to-yaml" class="sectionRef sec-ref"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a>.
+              </dd>
+              <dt><a data-link-type="idl" data-lt="flatten()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-flatten"><code>flatten</code></a><code>()</code></dt>
+              <dd>
+                Updates step 7 of the <a data-link-type="idl" data-lt="flatten()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-flatten"><code>flatten</code></a><code>()</code> algorithm
+                to serialize the the result as YAML rather than JSON
+                as defined in <a href="#conversion-to-yaml" class="sectionRef sec-ref"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a>.
+              </dd>
+              <dd>
+                Updates step 22 of the
+                <a href="https://www.w3.org/TR/json-ld11-framing/#dom-jsonldprocessor-frame">frame()</a>
+                algorithm to serialize the the result as YAML rather than JSON
+                as defined in <a href="#conversion-to-yaml" class="sectionRef sec-ref"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a>.
+              </dd>
+              <dt><a data-link-type="idl" data-lt="fromRdf()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-fromrdf"><code>fromRdf</code></a><code>()</code></dt>
+              <dd>
+                Updates step 3 of the <a data-link-type="idl" data-lt="fromRdf()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-fromrdf"><code>fromRdf</code></a><code>()</code> algorithm
+                to serialize the the result as YAML rather than JSON
+                as defined in <a href="#conversion-to-yaml" class="sectionRef sec-ref"><bdi class="secno">E.3.2 </bdi>Conversion to YAML</a>.
+              </dd>
+              <dd>
+                Updates the
+                <a href="https://www.w3.org/TR/json-ld11-api/#rdf-to-object-conversion">RDF to Object Conversion</a> algorithm
+                before step 2.6 as follows:
+                <blockquote>
+                  Otherwise, if both the <a data-link-type="idl" data-type="dict-member" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions-usenativetypes"><code>useNativeTypes</code></a>
+                  and <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-5"><code>extendedYAML</code></a> flags are set
+                  and the
+                  <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a>
+                  of <var>value</var> is not <code>xsd:string</code>:
+                  <ol>
+                    <li>
+                      If <var>value</var> is a <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged string</a>
+                      set <var>converted value</var> to a new <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a>
+                      composed of the
+                      <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form">lexical form</a>
+                      of <var>value</var> and
+                      <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</a>
+                      composed of <code>https://www.w3.org/ns/i18n#</code> followed by
+                      the
+                      <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a>
+                      of <var>value</var>.
+                    </li>
+                    <li>
+                      Otherwise, et <var>converted value</var> to <var>value</var>.
+                    </li>
+                  </ol>
+                </blockquote>
+              </dd>
+              <dt><a data-link-type="idl" data-lt="toRdf()" data-type="method" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor-tordf"><code>toRdf</code></a><code>()</code></dt>
+              <dd>
+                Updates the
+                <a href="https://www.w3.org/TR/json-ld11-api/#object-to-rdf-conversion">Object to RDF Conversion</a> algorithm
+                before step 10 as follows:
+                <blockquote>
+                  <ol>
+                    <li>
+                      Otherwise, if <var>value</var> is an <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a>,
+                      <var>value</var> is left unmodified.
+                      <span class="note">
+                    This will only be the case when processing a value from an
+                    <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-8">extended internal representation</a>.
+                  </span>
+                    </li>
+                  </ol>
+                </blockquote>
+              </dd></dl>
+          </section>
+
+          <section id="jsonldoptions"><div class="header-wrapper"><h5 id="e-3-4-2-jsonldoptions"><bdi class="secno">E.3.4.2 </bdi>JsonLdOptions</h5><a class="self-link" href="#jsonldoptions" aria-label="Permalink for Section E.3.4.2"></a></div>
+            
+            <p>The <a data-link-type="idl" data-lt="JsonLdOptions" data-type="dictionary" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions"><code>JsonLdOptions</code></a> type is used to pass various options to the
+              <a data-link-type="idl" data-lt="JsonLdProcessor" data-type="interface" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldprocessor"><code>JsonLdProcessor</code></a> methods.</p>
+
+            <pre class="idl def" id="webidl-1917346355"><span class="idlHeader"><a class="self-link" href="#webidl-1917346355">WebIDL</a></span><code><span data-idl="" class="idlDictionary" id="idl-def-jsonldoptions-partial-1" data-title="JsonLdOptions">partial dictionary <a data-idl="partial" data-link-type="dictionary" data-title="JsonLdOptions" class="idlID" data-dfn-for="JsonLdOptions" data-type="dictionary" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonldoptions">JsonLdOptions</a> {<span data-idl="" class="idlMember" id="idl-def-jsonldoptions-extendedyaml" data-title="extendedYAML" data-dfn-for="JsonLdOptions"><span class="idlType">
+  <a data-link-type="idl" href="https://infra.spec.whatwg.org/#boolean">boolean</a></span> <a class="internalDFN idlName" data-link-type="dict-member" href="#dom-jsonldoptions-extendedyaml" id="ref-for-dom-jsonldoptions-extendedyaml-6"><code>extendedYAML</code></a> = false;</span>
+};</span></code></pre>
+
+            <p>
+              In addition to those options defined in the
+              JSON-LD 1.1 API [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>]
+              and JSON-LD 1.1 Framing [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-framing" title="JSON-LD 1.1 Framing">JSON-LD11-FRAMING</a></cite>],
+              this specification defines these additional options:
+            </p>
+
+            <dl data-sort=""><dt><dfn data-dfn-for="JsonLdOptions" data-export="" data-dfn-type="dict-member" id="dom-jsonldoptions-extendedyaml" data-idl="field" data-title="extendedYAML" data-type="boolean" tabindex="0" aria-haspopup="dialog"><code>extendedYAML</code></dfn></dt>
+              <dd>
+                When used for serializing the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+                (or <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-9">extended internal representation</a>)
+                into a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">YAML representation graph</a>:
+
+                <ul>
+                  <li>
+                    If set, allows the use of <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a>
+                    when serializing <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a> values
+                    having datatypes other than <code>xsd:string</code>
+                    or <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string">language-tagged strings</a>
+                    as <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">scalar</a> values.
+                  </li>
+                  <li>
+                    Otherwise, it serializes <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literal</a> values
+                    to the closest <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">scalar</a> representation
+                    from the <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a>.
+                  </li>
+                </ul>
+              </dd>
+              <dd>
+                When used for the <a data-link-type="idl" data-lt="documentLoader" href="https://www.w3.org/TR/json-ld11/#dom-jsonldoptions-documentloader"><code>documentLoader</code></a>,
+                it causes documents of type <code>application/ld+yaml</code>
+                to be parsed into a <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#representation-graph">YAML representation graph</a>
+                and generates an <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+                (or <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-10">extended internal representation</a>):
+
+                <ul>
+                  <li>
+                    If set, it creates an <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-11">extended internal representation</a>
+                    and transforms <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#scalar">YAML scalar</a> values
+                    having <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a>
+                    — outside those allowed for the
+                    <a href="https://yaml.org/spec/1.2.2/#core-schema">YAML Core Schema</a> —
+                    to <a data-link-type="dfn" href="https://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</a>.
+                  </li>
+                  <li>
+                    Otherwise, it drops any <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#node-tags">node tags</a>
+                  </li>
+                </ul>
+              </dd></dl>
+          </section>
+
+          <section class="documentLoader" id="remote-document-and-context-retrieval"><div class="header-wrapper"><h5 id="e-3-4-3-remote-document-and-context-retrieval"><bdi class="secno">E.3.4.3 </bdi>Remote Document and Context Retrieval</h5><a class="self-link" href="#remote-document-and-context-retrieval" aria-label="Permalink for Section E.3.4.3"></a></div>
+            
+
+            <p>This section describes an update to the
+              built-in <a data-link-type="idl" data-lt="LoadDocumentCallback" data-type="callback" href="https://www.w3.org/TR/json-ld11-api/#dom-loaddocumentcallback"><code>LoadDocumentCallback</code></a>
+              to load <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#streams">YAML streams</a> and <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#documents">documents</a>
+              into the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>,
+              or into the <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-12">extended internal representation</a>
+              if the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-7"><code>extendedYAML</code></a> API flag is <code>true</code>.</p>
+
+            <p>
+              The <a data-link-type="idl" data-lt="LoadDocumentCallback" data-type="callback" href="https://www.w3.org/TR/json-ld11-api/#dom-loaddocumentcallback"><code>LoadDocumentCallback</code></a> algorithm in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>]
+              is updated as follows:
+            </p>
+
+            <ul>
+              <li>
+                <a href="https://www.w3.org/TR/json-ld11-api/#LoadDocumentCallback-step-2">Step 2</a>
+                is updated to prefer
+                <a href="https://www.rfc-editor.org/rfc/rfc2045#section-5">Content-Type</a> <code>application/ld+yaml</code>,
+                followed by <code>application/yaml</code>,
+                followed by the other specified
+                <a href="https://www.rfc-editor.org/rfc/rfc2045#section-5">Content-Types</a>.
+              </li>
+              <li>
+                After <a href="https://www.w3.org/TR/json-ld11-api/#LoadDocumentCallback-step-5">step 5</a>,
+                add the following processing step:
+                Otherwise, if the retrieved resource's
+                <a href="https://www.rfc-editor.org/rfc/rfc2045#section-5">Content-Type</a>
+                is either <code>application/yaml</code>
+                or any media type with a <code>+yaml</code> suffix as defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6839" title="Additional Media Type Structured Syntax Suffixes">RFC6839</a></cite>]
+                transform <var>document</var> to the <a data-link-type="dfn" href="https://www.w3.org/TR/json-ld11-api/#dfn-internal-representation">internal representation</a>
+                (or <a href="#dfn-extended-internal-representation" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-extended-internal-representation-13">extended internal representation</a>)
+                as described in <a href="#conversion-to-ir" class="sectionRef sec-ref"><bdi class="secno">E.3.1 </bdi>Conversion to the Internal Representation</a>.
+                Additionally, if the <a data-link-type="idl" data-type="attribute" href="https://www.w3.org/TR/json-ld11-api/#dom-remotedocument-profile"><code>profile</code></a> parameter
+                includes <code>http://www.w3.org/ns/json-ld#extended</code>, set the <a data-link-type="idl" href="#dom-jsonldoptions-extendedyaml" class="internalDFN" id="ref-for-dom-jsonldoptions-extendedyaml-8"><code>extendedYAML</code></a> option to <code>true</code>.
+              </li>
+            </ul>
+
+            <div class="note" role="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-5" aria-level="6"><span>Note</span></div><p class="">
+              These updates are intended to be compatible with other updates
+              to the <a data-link-type="idl" data-lt="LoadDocumentCallback" data-type="callback" href="https://www.w3.org/TR/json-ld11-api/#dom-loaddocumentcallback"><code>LoadDocumentCallback</code></a>, such as
+              <a href="https://www.w3.org/TR/json-ld11-api/#process-html">Process HTML</a>
+              as defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11-api" title="JSON-LD 1.1 Processing Algorithms and API">JSON-LD11-API</a></cite>].
+            </p></div>
+          </section>
+
+          <section id="yamllderrorcode"><div class="header-wrapper"><h5 id="e-3-4-4-yamllderrorcode"><bdi class="secno">E.3.4.4 </bdi>YamlLdErrorCode</h5><a class="self-link" href="#yamllderrorcode" aria-label="Permalink for Section E.3.4.4"></a></div>
+            
+            <p>The <dfn data-export="" data-dfn-type="enum" id="dom-yamllderrorcode" data-idl="enum" data-title="YamlLdErrorCode" data-dfn-for="" tabindex="0" aria-haspopup="dialog"><code>YamlLdErrorCode</code></dfn> represents the collection of valid YAML-LD error codes,
+              which extends the <a data-link-type="idl" data-lt="JsonLdErrorCode" data-type="enum" href="https://www.w3.org/TR/json-ld11-api/#dom-jsonlderrorcode"><code>JsonLdErrorCode</code></a> definitions.</p>
+
+            <pre class="idl def" id="webidl-808568034"><span class="idlHeader"><a class="self-link" href="#webidl-808568034">WebIDL</a></span><code><span data-idl="" class="idlEnum" id="idl-def-yamllderrorcode" data-title="YamlLdErrorCode">enum <a class="internalDFN idlID" data-link-type="enum" href="#dom-yamllderrorcode" id="ref-for-dom-yamllderrorcode-1"><code>YamlLdErrorCode</code></a> {
+  <span class="idlEnumItem">"<a class="internalDFN" data-link-type="enum-value" href="#dom-yamllderrorcode-invalid-encoding" id="ref-for-dom-yamllderrorcode-invalid-encoding-2"><code>invalid-encoding</code></a>"</span>,
+  <span class="idlEnumItem">"<a class="internalDFN" data-link-type="enum-value" href="#dom-yamllderrorcode-mapping-key-error" id="ref-for-dom-yamllderrorcode-mapping-key-error-2"><code>mapping-key-error</code></a>"</span>,
+  <span class="idlEnumItem">"<a class="internalDFN" data-link-type="enum-value" href="#dom-yamllderrorcode-profile-error" id="ref-for-dom-yamllderrorcode-profile-error-3"><code>profile-error</code></a>"</span>
+};</span></code></pre>
+
+            <dl data-dfn-for="YamlLdErrorCode" data-sort=""><dt><dfn data-export="" data-dfn-type="enum-value" id="dom-yamllderrorcode-invalid-encoding" data-idl="enum-value" data-title="invalid-encoding" data-dfn-for="YamlLdErrorCode" tabindex="0" aria-haspopup="dialog"><code>invalid-encoding</code></dfn></dt>
+              <dd>The character encoding of an input is invalid.</dd>
+              <dt><dfn data-export="" data-dfn-type="enum-value" id="dom-yamllderrorcode-mapping-key-error" data-idl="enum-value" data-title="mapping-key-error" data-dfn-for="YamlLdErrorCode" tabindex="0" aria-haspopup="dialog"><code>mapping-key-error</code></dfn></dt>
+              <dd>A <a data-link-type="dfn" href="https://yaml.org/spec/1.2.2/#mapping">YAML mapping</a> key was found that was not a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#javascript-string">string</a>.</dd>
+              <dt><dfn data-export="" data-dfn-type="enum-value" id="dom-yamllderrorcode-profile-error" data-idl="enum-value" data-title="profile-error" data-dfn-for="YamlLdErrorCode" tabindex="0" aria-haspopup="dialog"><code>profile-error</code></dfn></dt>
+              <dd>The parsed YAML document contains features incompatible with the specified profile.</dd></dl>
+          </section>
+        </section>
+
+        <section id="implementations"><div class="header-wrapper"><h4 id="e-3-5-implementations"><bdi class="secno">E.3.5 </bdi>Implementations</h4><a class="self-link" href="#implementations" aria-label="Permalink for Section E.3.5"></a></div>
+          
+
+          <p>
+            TODO: Implementations for Extended Internal Representation.
+          </p>
+        </section>
+
+      </section>
+
+      <section id="convert-extended-yaml-ld-to-basic-yaml-ld-and-back"><div class="header-wrapper"><h3 id="e-4-convert-extended-yaml-ld-to-basic-yaml-ld-and-back"><bdi class="secno">E.4 </bdi>Convert Extended YAML-LD to Basic YAML-LD and back</h3><a class="self-link" href="#convert-extended-yaml-ld-to-basic-yaml-ld-and-back" aria-label="Permalink for Section E.4"></a></div>
+        
+
+        <p>
+          This approach is simpler than the Extended Internal Representation because it
+          does not require any changes to the internal structures of existing JSON-LD
+          libraries.
+        </p>
+
+        <p>
+          Instead, we implement two API functions:
+        </p>
+
+        <dl>
+          <dt><code>extended_to_basic(extended_document: YAML-LD) → YAML-LD</code></dt>
+          <dd>
+            <ul>
+              <li>Converts the document to Basic YAML-LD form</li>
+            </ul>
+          </dd>
+
+          <dt><code>basic_to_extended(basic_document: YAML-LD) → YAML-LD</code></dt>
+          <dd>
+            <ul>
+              <li>Converts YAML-LD → JSON</li>
+              <li>Performs JSON-LD expansion → the resulting JSON-LD document</li>
+              <li>Converts Expanded JSON-LD document back to YAML-LD</li>
+              <li>
+                Converts it to the Extended form, making
+                use of YAML-LD features to express the document more concisely.
+              </li>
+            </ul>
+          </dd>
+        </dl>
+
+        <div class="note" role="note" id="issue-container-generatedID-13"><div role="heading" class="note-title marker" id="h-note-6" aria-level="4"><span>Note</span></div><div class="">
+          You won't typically need to perform these steps manually
+          because libraries such as <code>rdflib</code> will take care of them
+          under the covers, but it can help with troubleshooting and
+          optimization to know what's going on. So, you start with YAML,
+          convert it to JSON, perform JSON-LD Expansion, convert that to
+          YAML-LD, and do any necessary <em>basic → extended</em> or <em>extended → basic</em>
+          conversion on the YAML-LD. Alternatively, your library might do
+          YAML-LD expansion directly on the initial YAML document, and then
+          do any necessary <em>basic → extended</em> or <em>extended → basic</em> conversion on
+          the YAML-LD.
+        </div></div>
+
+        <p>
+          Both of these functions recursively process the source document.
+          Every branch and leaf are copied as is, unless they match one of the following
+          cases.
+        </p>
+
+        <p>Generally, these two equalities <strong>do not</strong> hold:</p>
+
+        <ul>
+          <li><code>extended_to_basic(basic_to_extended(document)) = document</code></li>
+          <li><code>basic_to_extended(extended_to_basic(document)) = document</code></li>
+        </ul>
+
+        <p>
+          When the extended → basic conversion resolves YAML tags
+          we no longer know where the original document used tags and where
+          it used <code>@type</code> calls. Thus, information is lost.
+        </p>
+
+        <p>
+          Both of these functions lose information about anchors and
+          references because they're resolved by the YAML processor
+          underlying the implementation.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th></th>
+              <th><code>extended_to_basic</code></th>
+              <th><code>basic_to_extended</code></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>YAML Tags</th>
+              <td>
+                <a href="#tags-to-types">Convert</a> YAML <code>!tags</code>
+                → <code>@type</code> JSON-LD keywords
+              </td>
+              <td>(nothing)</td>
+            </tr>
+            <tr>
+              <th>Anchors and aliases</th>
+              <td><a href="#resolve-anchors-aliases">Resolve</a> anchors and aliases</td>
+              <td>(nothing)</td>
+            </tr>
+            <tr>
+              <th>Comments</th>
+              <td>Keep as-is</td>
+              <td>Remove<br><small>(Due to JSON-LD &amp; Expansion.)</small></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <section id="tags-to-types"><div class="header-wrapper"><h4 id="e-4-1-yaml-tags-type-declarations"><bdi class="secno">E.4.1 </bdi>YAML <code>!tags</code> → <code>@type</code> declarations</h4><a class="self-link" href="#tags-to-types" aria-label="Permalink for Section E.4.1"></a></div>
+          
+
+          <div style="display: flex">
+              <div>
+                <div class="example" id="example-extended-yaml-ld-with-tags">
+        <div class="marker">
+    <a class="self-link" href="#example-extended-yaml-ld-with-tags">Example<bdi> 12</bdi></a><span class="example-title">: Extended YAML-LD with tags</span>
+  </div> <pre class="yaml" data-result-for="YAML-LD: Tags" data-content-type="application/ld+json" aria-busy="false"><code class="hljs">%TAG !xsd! http://www.w3.org/2001/XMLSchema%23
+---
+"@context": https://schema.org
+"@id": https://github.com/gkellogg
+"@type": Person
+name: !xsd!string Gregg Kellogg
+birthDate: !xsd!date 1970-01-01</code></pre>
+      </div>
+              </div>
+              <div>
+                <div class="example" id="example-basic-yaml-ld">
+        <div class="marker">
+    <a class="self-link" href="#example-basic-yaml-ld">Example<bdi> 13</bdi></a><span class="example-title">: Basic YAML-LD</span>
+  </div> <pre class="yaml" data-result-for="YAML-LD: Tags" data-content-type="application/ld+json" aria-busy="false"><code class="hljs">"@context":
+  - "@import": https://schema.org
+  - xsd: "http://www.w3.org/2001/XMLSchema#"
+"@id": https://github.com/gkellogg
+"@type": Person
+name: Gregg Kellogg
+birthDate:
+  "@value": 1970-01-01
+  "@type": xsd:date</code></pre>
+      </div>
+              </div>
+            </div>
+        </section>
+
+        <section id="resolve-anchors-aliases"><div class="header-wrapper"><h4 id="e-4-2-anchors-and-aliases"><bdi class="secno">E.4.2 </bdi><code>&amp;anchors</code> and <code>*aliases</code></h4><a class="self-link" href="#resolve-anchors-aliases" aria-label="Permalink for Section E.4.2"></a></div>
+          
+
+          <p>
+            Substitute every <code>*alias</code> with the content of
+            the <code>&amp;anchor</code> alias references to. This is standard behavior
+            of YAML tools and libraries.
+          </p>
+        </section>
+      </section>
+
+      <section id="frag" class="informative"><div class="header-wrapper"><h3 id="e-5-fragment-identifiers"><bdi class="secno">E.5 </bdi>Fragment identifiers</h3><a class="self-link" href="#frag" aria-label="Permalink for Section E.5"></a></div><p><em>This section is non-normative.</em></p>
+        
+        <p>Fragment identifiers used with <a href="#application-ld-yaml">application/ld+yaml</a>
+         are treated as in RDF syntaxes, as per
+         <a href="https://www.w3.org/TR/rdf11-concepts/#section-fragID">RDF 1.1 Concepts and Abstract Syntax</a>
+         [<cite><a class="bibref" data-link-type="biblio" href="#bib-rdf11-concepts" title="RDF 1.1 Concepts and Abstract Syntax">RDF11-CONCEPTS</a></cite>]
+         and do not follow the process defined for <code>application/yaml</code>.
+        </p>
+
+        <div class="note" id="issue-container-generatedID-14"><div role="heading" class="ednote-title marker" id="h-ednote-6" aria-level="4"><span>Editor's note</span></div><div class="">
+          Perhaps more on fragment identifiers from
+          <a href="https://github.com/json-ld/yaml-ld/issues/31">Issue 31</a>.
+        </div></div>
+      </section>
+    </section>
+  
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="f-references"><bdi class="secno">F. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix F."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="f-1-normative-references"><bdi class="secno">F.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix F.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-i-d.ietf-httpapi-yaml-mediatypes">[I-D.ietf-httpapi-yaml-mediatypes]</dt><dd>
+      <a href="https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html"><cite>YAML Media Type</cite></a>. Roberto Polli; Erik Wilde; Eemeli Aro.  IETF. 2022-08-05. WG Document. URL: <a href="https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html">https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html</a>
+    </dd><dt id="bib-json">[JSON]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8259"><cite>The JavaScript Object Notation (JSON) Data Interchange Format</cite></a>. T. Bray, Ed..  IETF. December 2017. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8259">https://www.rfc-editor.org/rfc/rfc8259</a>
+    </dd><dt id="bib-json-ld11">[JSON-LD11]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld11/"><cite>JSON-LD 1.1</cite></a>. Gregg Kellogg; Pierre-Antoine Champin; Dave Longley.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11/">https://www.w3.org/TR/json-ld11/</a>
+    </dd><dt id="bib-json-ld11-api">[JSON-LD11-API]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld11-api/"><cite>JSON-LD 1.1 Processing Algorithms and API</cite></a>. Gregg Kellogg; Dave Longley; Pierre-Antoine Champin.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11-api/">https://www.w3.org/TR/json-ld11-api/</a>
+    </dd><dt id="bib-linked-data">[LINKED-DATA]</dt><dd>
+      <a href="https://www.w3.org/DesignIssues/LinkedData.html"><cite>Linked Data Design Issues</cite></a>. Tim Berners-Lee.  W3C. 27 July 2006. W3C-Internal Document. URL: <a href="https://www.w3.org/DesignIssues/LinkedData.html">https://www.w3.org/DesignIssues/LinkedData.html</a>
+    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc3986">[RFC3986]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc3986"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3986">https://www.rfc-editor.org/rfc/rfc3986</a>
+    </dd><dt id="bib-rfc3987">[RFC3987]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc3987"><cite>Internationalized Resource Identifiers (IRIs)</cite></a>. M. Duerst; M. Suignard.  IETF. January 2005. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3987">https://www.rfc-editor.org/rfc/rfc3987</a>
+    </dd><dt id="bib-rfc4288">[RFC4288]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc4288"><cite>Media Type Specifications and Registration Procedures</cite></a>. N. Freed; J. Klensin.  IETF. December 2005. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc4288">https://www.rfc-editor.org/rfc/rfc4288</a>
+    </dd><dt id="bib-rfc6838">[RFC6838]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc6838"><cite>Media Type Specifications and Registration Procedures</cite></a>. N. Freed; J. Klensin; T. Hansen.  IETF. January 2013. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc6838">https://www.rfc-editor.org/rfc/rfc6838</a>
+    </dd><dt id="bib-rfc6906">[RFC6906]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc6906"><cite>The 'profile' Link Relation Type</cite></a>. E. Wilde.  IETF. March 2013. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc6906">https://www.rfc-editor.org/rfc/rfc6906</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd><dt id="bib-rfc9110">[RFC9110]</dt><dd>
+      <a href="https://httpwg.org/specs/rfc9110.html"><cite>HTTP Semantics</cite></a>. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://httpwg.org/specs/rfc9110.html">https://httpwg.org/specs/rfc9110.html</a>
+    </dd><dt id="bib-yaml">[YAML]</dt><dd>
+      <a href="https://yaml.org/spec/1.2.2/"><cite>YAML Ain’t Markup Language (YAML™) version 1.2.2</cite></a>. Oren Ben-Kiki; Clark Evans; Ingy döt Net. 2021-10-01. URL: <a href="https://yaml.org/spec/1.2.2/">https://yaml.org/spec/1.2.2/</a>
+    </dd></dl>
+  </section><section id="informative-references"><div class="header-wrapper"><h3 id="f-2-informative-references"><bdi class="secno">F.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix F.2"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-ecmascript">[ECMASCRIPT]</dt><dd>
+      <a href="https://tc39.es/ecma262/multipage/"><cite>ECMAScript Language Specification</cite></a>.  Ecma International. URL: <a href="https://tc39.es/ecma262/multipage/">https://tc39.es/ecma262/multipage/</a>
+    </dd><dt id="bib-infra">[INFRA]</dt><dd>
+      <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+    </dd><dt id="bib-json-ld">[JSON-LD]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld/"><cite>JSON-LD 1.0</cite></a>. Manu Sporny; Gregg Kellogg; Markus Lanthaler.  W3C. 3 November 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld/">https://www.w3.org/TR/json-ld/</a>
+    </dd><dt id="bib-json-ld-bp">[json-ld-bp]</dt><dd>
+      <a href="https://w3c.github.io/json-ld-bp/"><cite>JSON-LD Best Practices</cite></a>. Gregg Kellogg; Ivan Herman; BigBlueHat; A. Soroka; Ruben Taelman; David I. Lehn; Philippe Le Hegaret.  W3C. 2022-05-24. W3C Group Note. URL: <a href="https://w3c.github.io/json-ld-bp/">https://w3c.github.io/json-ld-bp/</a>
+    </dd><dt id="bib-json-ld11-framing">[JSON-LD11-FRAMING]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld11-framing/"><cite>JSON-LD 1.1 Framing</cite></a>. Dave Longley; Gregg Kellogg; Pierre-Antoine Champin.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11-framing/">https://www.w3.org/TR/json-ld11-framing/</a>
+    </dd><dt id="bib-owl2-syntax">[OWL2-SYNTAX]</dt><dd>
+      <a href="https://www.w3.org/TR/owl2-syntax/"><cite>OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)</cite></a>. Boris Motik; Peter Patel-Schneider; Bijan Parsia.  W3C. 11 December 2012. W3C Recommendation. URL: <a href="https://www.w3.org/TR/owl2-syntax/">https://www.w3.org/TR/owl2-syntax/</a>
+    </dd><dt id="bib-rdf-schema">[RDF-SCHEMA]</dt><dd>
+      <a href="https://www.w3.org/TR/rdf-schema/"><cite>RDF Schema 1.1</cite></a>. Dan Brickley; Ramanathan Guha.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/rdf-schema/">https://www.w3.org/TR/rdf-schema/</a>
+    </dd><dt id="bib-rdf11-concepts">[RDF11-CONCEPTS]</dt><dd>
+      <a href="https://www.w3.org/TR/rdf11-concepts/"><cite>RDF 1.1 Concepts and Abstract Syntax</cite></a>. Richard Cyganiak; David Wood; Markus Lanthaler.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/rdf11-concepts/">https://www.w3.org/TR/rdf11-concepts/</a>
+    </dd><dt id="bib-rfc2045">[rfc2045]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2045"><cite>Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</cite></a>. N. Freed; N. Borenstein.  IETF. November 1996. Draft Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc2045">https://www.rfc-editor.org/rfc/rfc2045</a>
+    </dd><dt id="bib-rfc6839">[RFC6839]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc6839"><cite>Additional Media Type Structured Syntax Suffixes</cite></a>. T. Hansen; A. Melnikov.  IETF. January 2013. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc6839">https://www.rfc-editor.org/rfc/rfc6839</a>
+    </dd><dt id="bib-rfc7464">[RFC7464]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7464"><cite>JavaScript Object Notation (JSON) Text Sequences</cite></a>. N. Williams.  IETF. February 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7464">https://www.rfc-editor.org/rfc/rfc7464</a>
+    </dd><dt id="bib-turtle">[TURTLE]</dt><dd>
+      <a href="https://www.w3.org/TR/turtle/"><cite>RDF 1.1 Turtle</cite></a>. Eric Prud'hommeaux; Gavin Carothers.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/turtle/">https://www.w3.org/TR/turtle/</a>
+    </dd><dt id="bib-uri">[URI]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc3986"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3986">https://www.rfc-editor.org/rfc/rfc3986</a>
+    </dd><dt id="bib-xmlschema11-2">[xmlschema11-2]</dt><dd>
+      <a href="https://www.w3.org/TR/xmlschema11-2/"><cite>W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</cite></a>. David Peterson; Sandy Gao; Ashok Malhotra; Michael Sperberg-McQueen; Henry Thompson; Paul V. Biron et al.  W3C. 5 April 2012. W3C Recommendation. URL: <a href="https://www.w3.org/TR/xmlschema11-2/">https://www.w3.org/TR/xmlschema11-2/</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-yaml-ld-stream" aria-label="Links in this document to definition: YAML-LD stream">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-yaml-ld-stream" aria-label="Permalink for definition: YAML-LD stream. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-yaml-ld-stream-1" title="§ D. Streams">§ D. Streams</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-yaml-ld-document" aria-label="Links in this document to definition: YAML-LD document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-yaml-ld-document" aria-label="Permalink for definition: YAML-LD document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-yaml-ld-document-1" title="§ 1. Introduction">§ 1. Introduction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-2" title="§ 1.2 Terminology">§ 1.2 Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-3" title="§ 2. Conformance">§ 2. Conformance</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-4" title="§ 4.2 Encoding">§ 4.2 Encoding</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-5" title="§ 4.3 Comments">§ 4.3 Comments</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-6" title="§ 4.4 Anchors and Aliases">§ 4.4 Anchors and Aliases</a> <a href="#ref-for-dfn-yaml-ld-document-7" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-8" title="§ A.1 application/ld+yaml">§ A.1 application/ld+yaml</a> <a href="#ref-for-dfn-yaml-ld-document-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-yaml-ld-document-10" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-11" title="§ D. Streams">§ D. Streams</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-document-12" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-json-document" aria-label="Links in this document to definition: JSON document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-json-document" aria-label="Permalink for definition: JSON document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-json-document-1" title="§ 6. Interoperability Considerations">§ 6. Interoperability Considerations</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-convenience-context" aria-label="Links in this document to definition: Convenience Context">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-convenience-context" aria-label="Permalink for definition: Convenience Context. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-convenience-context-1" title="§ B. Best Practices">§ B. Best Practices</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-yaml-ld-basic-profile" aria-label="Links in this document to definition: YAML-LD Basic profile">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-yaml-ld-basic-profile" aria-label="Permalink for definition: YAML-LD Basic profile. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-1" title="§ 2. Conformance">§ 2. Conformance</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-2" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-3" title="§ E.3.1 Conversion to the Internal Representation">§ E.3.1 Conversion to the Internal Representation</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-4" title="§ E.3.1.6 Converting a YAML alias node">§ E.3.1.6 Converting a YAML alias node</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-5" title="§ E.3.3 Application Profiles">§ E.3.3 Application Profiles</a> <a href="#ref-for-dfn-yaml-ld-basic-profile-6" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-7" title="§ E.3.3.1 YAML-LD Basic Profile">§ E.3.3.1 YAML-LD Basic Profile</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-8" title="§ E.3.3.2 YAML-LD Extended Profile">§ E.3.3.2 YAML-LD Extended Profile</a> <a href="#ref-for-dfn-yaml-ld-basic-profile-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-yaml-ld-basic-profile-10" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-basic-profile-11" title="§ E.3.3.2.1 The JSON-LD Extended Internal Representation">§ E.3.3.2.1 The JSON-LD Extended Internal Representation</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-yaml-ld-extended-profile" aria-label="Links in this document to definition: YAML-LD extended profile">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-yaml-ld-extended-profile" aria-label="Permalink for definition: YAML-LD extended profile. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-yaml-ld-extended-profile-1" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> <a href="#ref-for-dfn-yaml-ld-extended-profile-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-extended-profile-3" title="§ E.3.3 Application Profiles">§ E.3.3 Application Profiles</a> <a href="#ref-for-dfn-yaml-ld-extended-profile-4" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-extended-profile-5" title="§ E.3.3.2 YAML-LD Extended Profile">§ E.3.3.2 YAML-LD Extended Profile</a> 
+    </li><li>
+      <a href="#ref-for-dfn-yaml-ld-extended-profile-6" title="§ E.3.4 The Application Programming Interface">§ E.3.4 The Application Programming Interface</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-extended-internal-representation" aria-label="Links in this document to definition: JSON-LD extended internal representation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-extended-internal-representation" aria-label="Permalink for definition: JSON-LD extended internal representation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-extended-internal-representation-1" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> <a href="#ref-for-dfn-extended-internal-representation-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-extended-internal-representation-3" title="§ E.3.3.2 YAML-LD Extended Profile">§ E.3.3.2 YAML-LD Extended Profile</a> <a href="#ref-for-dfn-extended-internal-representation-4" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-extended-internal-representation-5" title="§ E.3.3.2.1 The JSON-LD Extended Internal Representation">§ E.3.3.2.1 The JSON-LD Extended Internal Representation</a> <a href="#ref-for-dfn-extended-internal-representation-6" title="Reference 2">(2)</a> <a href="#ref-for-dfn-extended-internal-representation-7" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-extended-internal-representation-8" title="§ E.3.4.1 JsonLdProcessor">§ E.3.4.1 JsonLdProcessor</a> 
+    </li><li>
+      <a href="#ref-for-dfn-extended-internal-representation-9" title="§ E.3.4.2 JsonLdOptions">§ E.3.4.2 JsonLdOptions</a> <a href="#ref-for-dfn-extended-internal-representation-10" title="Reference 2">(2)</a> <a href="#ref-for-dfn-extended-internal-representation-11" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-extended-internal-representation-12" title="§ E.3.4.3 Remote Document and Context Retrieval">§ E.3.4.3 Remote Document and Context Retrieval</a> <a href="#ref-for-dfn-extended-internal-representation-13" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-jsonldoptions-extendedyaml" aria-label="Links in this document to definition: extendedYAML">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dom-jsonldoptions-extendedyaml" aria-label="Permalink for definition: extendedYAML. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-1917346355">IDL</a>
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-1" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-2" title="§ E.3.1.5 Converting a YAML scalar">§ E.3.1.5 Converting a YAML scalar</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-3" title="§ E.3.1.6 Converting a YAML alias node">§ E.3.1.6 Converting a YAML alias node</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-4" title="§ E.3.2 Conversion to YAML">§ E.3.2 Conversion to YAML</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-5" title="§ E.3.4.1 JsonLdProcessor">§ E.3.4.1 JsonLdProcessor</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-6" title="§ E.3.4.2 JsonLdOptions">§ E.3.4.2 JsonLdOptions</a> 
+    </li><li>
+      <a href="#ref-for-dom-jsonldoptions-extendedyaml-7" title="§ E.3.4.3 Remote Document and Context Retrieval">§ E.3.4.3 Remote Document and Context Retrieval</a> <a href="#ref-for-dom-jsonldoptions-extendedyaml-8" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-yamllderrorcode" aria-label="Links in this document to definition: YamlLdErrorCode">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dom-yamllderrorcode" aria-label="Permalink for definition: YamlLdErrorCode. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-808568034">IDL</a>
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dom-yamllderrorcode-1" title="§ E.3.4.4 YamlLdErrorCode">§ E.3.4.4 YamlLdErrorCode</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-yamllderrorcode-invalid-encoding" aria-label="Links in this document to definition: invalid-encoding">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dom-yamllderrorcode-invalid-encoding" aria-label="Permalink for definition: invalid-encoding. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-808568034">IDL</a>
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dom-yamllderrorcode-invalid-encoding-1" title="§ 4.2 Encoding">§ 4.2 Encoding</a> 
+    </li><li>
+      <a href="#ref-for-dom-yamllderrorcode-invalid-encoding-2" title="§ E.3.4.4 YamlLdErrorCode">§ E.3.4.4 YamlLdErrorCode</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-yamllderrorcode-mapping-key-error" aria-label="Links in this document to definition: mapping-key-error">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dom-yamllderrorcode-mapping-key-error" aria-label="Permalink for definition: mapping-key-error. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-808568034">IDL</a>
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dom-yamllderrorcode-mapping-key-error-1" title="§ E.3.1.4 Converting a YAML mapping">§ E.3.1.4 Converting a YAML mapping</a> 
+    </li><li>
+      <a href="#ref-for-dom-yamllderrorcode-mapping-key-error-2" title="§ E.3.4.4 YamlLdErrorCode">§ E.3.4.4 YamlLdErrorCode</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dom-yamllderrorcode-profile-error" aria-label="Links in this document to definition: profile-error">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dom-yamllderrorcode-profile-error" aria-label="Permalink for definition: profile-error. Activate to close this dialog.">Permalink</a>
+        <span class="marker dfn-exported" title="Definition can be referenced by other specifications">exported</span> <a class="marker idl-block" title="Jump to IDL declaration" href="#webidl-808568034">IDL</a>
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dom-yamllderrorcode-profile-error-1" title="§ E.3 Extended Internal Representation">§ E.3 Extended Internal Representation</a> 
+    </li><li>
+      <a href="#ref-for-dom-yamllderrorcode-profile-error-2" title="§ E.3.1.6 Converting a YAML alias node">§ E.3.1.6 Converting a YAML alias node</a> 
+    </li><li>
+      <a href="#ref-for-dom-yamllderrorcode-profile-error-3" title="§ E.3.4.4 YamlLdErrorCode">§ E.3.4.4 YamlLdErrorCode</a> 
+    </li>
+  </ul>
+    </div><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>

--- a/publication-snapshots/CG-FINAL-2023-12-06/data/json-vs-yaml.yaml
+++ b/publication-snapshots/CG-FINAL-2023-12-06/data/json-vs-yaml.yaml
@@ -1,0 +1,132 @@
+"@context":
+  - https://json-ld.org/contexts/dollar-convenience.jsonld
+  - "@base": https://json-ld.github.io/
+    rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+    rdfs: http://www.w3.org/2000/01/rdf-schema#
+    prov: http://www.w3.org/ns/prov#
+
+$id: JSONOrYAMLFeature
+$reverse:
+  rdf:type:
+    - rdfs:label: UTF-8
+      $type: Encoding
+      json:
+        - prov:value: yes
+          prov:wasDerivedFrom: JSON#section-8.1
+      yaml:
+        - prov:value: yes
+          prov:wasDerivedFrom: YAML#52-character-encodings
+
+    - rdfs:label: UTF-16
+      json:
+        - prov:value: no
+          prov:wasDerivedFrom: JSON#section-8.1
+      yaml:
+        - prov:value: yes
+          prov:wasDerivedFrom: YAML#52-character-encodings
+
+    - rdfs:label: UTF-32
+      json:
+        - prov:value: no
+          prov:wasDerivedFrom: JSON#section-8.1
+      yaml:
+        - prov:value: yes
+          prov:wasDerivedFrom: YAML#52-character-encodings
+
+    - rdfs:label: "<code>{}</code> object"
+      rdf:type:
+        $id: native-data-types
+        rdfs:label: Native data types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-4
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#3211-nodes
+
+    - rdfs:label: "<code>[]</code> array"
+      $type: native-data-types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-5
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#3211-nodes
+
+    - rdfs:label: string
+      $type: native-data-types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-7
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#3211-nodes
+
+    - rdfs:label: number
+      $type: native-data-types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-6
+      yaml:
+        - prov:value: integer
+          prov:wasDerivedFrom: YAML#10213-integer
+        - prov:value: floating point
+          prov:wasDerivedFrom: YAML#10214-floating-point
+
+    - rdfs:label: bool
+      $type: native-data-types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-3
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#10212-boolean
+
+    - rdfs:label: null
+      $type: native-data-types
+      json:
+        prov:value: yes
+        prov:wasDerivedFrom: JSON#section-3
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#10211-null
+
+    - rdfs:label: Custom types
+      rdf:type:
+        $id: features
+        rdfs:label: Features
+      json: no
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#tags
+
+    - rdfs:label: Cycles
+      $type: features
+      json: no
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#321-representation-graph
+
+    - rdfs:label: Documents per file
+      json: 1
+      yaml:
+        prov:value: ⩾ 1
+        prov:wasDerivedFrom: YAML stream
+
+    - rdfs:label: Comments
+      json: no
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#3233-comments
+
+    - rdfs:label: Anchors & aliases
+      json: no
+      yaml:
+        prov:value: yes
+        prov:wasDerivedFrom: YAML#3222-anchors-and-aliases
+
+    - rdfs:label: Mapping key types
+      json: string
+      yaml:
+        prov:value: Any type representable in YAML, from strings to mappings
+        prov:wasDerivedFrom: YAML#3211-nodes

--- a/publication-snapshots/CG-FINAL-2023-12-06/data/namespace-prefixes.yaml
+++ b/publication-snapshots/CG-FINAL-2023-12-06/data/namespace-prefixes.yaml
@@ -1,0 +1,22 @@
+"@context":
+  - https://json-ld.org/contexts/dollar-convenience.jsonld
+  - "@base": https://json-ld.github.io/
+    rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+
+$id: NamespacePrefix
+$reverse:
+  rdf:type:
+    - prefix: ex
+      iri: https://example.org/
+    - prefix: i18n
+      iri: "https://www.w3.org/ns/i18n#"
+    - prefix: rdf
+      iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    - prefix: rdfs
+      iri: "http://www.w3.org/2000/01/rdf-schema#"
+    - prefix: xsd
+      iri: "http://www.w3.org/2001/XMLSchema#"
+    - prefix: schema
+      iri: https://schema.org/
+    - prefix: prov
+      iri: "http://www.w3.org/ns/prov#"

--- a/publication-snapshots/CG-FINAL-2023-12-06/data/spec.yaml
+++ b/publication-snapshots/CG-FINAL-2023-12-06/data/spec.yaml
@@ -1,0 +1,80 @@
+"@context":
+  - https://json-ld.org/contexts/dollar-convenience.jsonld
+  - "@base": https://json-ld.github.io/yaml-ld/spec/
+    rdfs: http://www.w3.org/2000/01/rdf-schema#
+    schema: https://schema.org/
+
+    rdfs:range:
+      "@type": "@id"
+
+    license:
+      "@type": "@id"
+
+$included:
+  - $id: schema:author
+    rdfs:range: schema:Person
+
+  - $id: https://json-ld.github.io/yaml-ld/spec/
+    rdfs:label: YAML-LD
+    schema:author:
+      - name: Vladimir Alexiev
+        $id: https://github.com/VladimirAlexiev
+
+      - name: Pierre-Antoine Champin
+        $id: https://github.com/pchampin
+
+      - name: Gregg Kellogg
+        $id: https://github.com/gkellogg
+
+      - name: Roberto Polli
+        $id: https://github.com/ioggstream
+
+      - name: Anatoly Scherbakov
+        country: am
+        $id: https://github.com/anatoly-scherbakov
+
+      - name: Ted Thibodeau Jr
+        $id: https://github.com/TallTed
+
+      - name: Benjamin Young
+        $id: https://github.com/BigBlueHat
+
+    license: https://spdx.org/licenses/W3C.html
+
+    schema:hasPart:
+      - rdfs:label: Abstract
+      - rdfs:label: Status of This Document
+      - rdfs:label: Introduction
+        schema:hasPart:
+          - rdfs:label: How to read this document
+          - rdfs:label: Terminology
+          - rdfs:label: Namespace prefixes
+      - rdfs:label: Conformance
+      - rdfs:label: Basic concepts
+        schema:hasPart:
+          - rdfs:label: JSON vs YAML comparison
+      - rdfs:label: Core requirements
+        $type: NormativeSection
+        schema:hasPart:
+          - rdfs:label: YAML features supported by YAML-LD
+          - rdfs:label: Encoding
+          - rdfs:label: Comments
+          - rdfs:label: Anchors and Aliases
+          - rdfs:label: Mapping Key Types
+
+      - rdfs:label: Security Considerations
+      - rdfs:label: Interoperability Considerations
+
+      - rdfs:label: IANA Considerations
+        $type: NormativeSection
+        schema:hasPart:
+          - rdfs:label: application/ld+yaml
+          - rdfs:label: Fragment identifiers
+          - rdfs:label: Examples
+
+      - rdfs:label: Best Practices
+      - rdfs:label: Why are comments treated as whitespace?
+      - rdfs:label: Streams
+
+      - rdfs:label: Extended YAML-LD Profile
+      - rdfs:label: References

--- a/spec/index.html
+++ b/spec/index.html
@@ -21,6 +21,7 @@
     copyrightStart:    "2020",
     shortName:  "yaml-ld",
     edDraftURI: "https://json-ld.github.io/yaml-ld/",
+    latestVersion: "https://www.w3.org/community/reports/json-ld/yaml-ld/",
     github: {
       repoURL: "https://github.com/json-ld/yaml-ld/",
         branch: "main"


### PR DESCRIPTION
This creates a snapshot in publication-snapshots/CG-FINAL-2023-12-06 including the rendered Overview.html and referenced data files, for publication on December 6th.

Requirements for publishing a report are [here](https://www.w3.org/community/reports/reqs/). I added a `latestVersion` configuration of "https://www.w3.org/community/reports/json-ld/yaml-ld/", while this version of the report would be published at "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/".

To get this uploaded, we follow the instructions in the [cg-reports](https://w3c.github.io/cg-reports/) repo and create a PR there, which would put these files in json-ld/CG-FINAL-yaml-ld-20231206/. It's not clear to me how the `latestVersion` URL is managed, or if it is at all. Presumably, this could be sorted out in the PR to https://github.com/w3c/cg-reports. It may be that we just need to use "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/" for `latestVersion`.