### PR TITLE
(closes #119) Introduce `extractAllScripts` flag to handle YAML streams

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -818,7 +818,7 @@ schema:hasPart:
         <dd>Not permitted.</dd>
 
         <dt>YAML Streams</dt>
-        <dd>Not supported.</dd>
+        <dd>Treated identically to arrays.</dd>
 
         <dt>Mapping key types other than <code>string</code></dt>
         <dd><a href="#mapping-key-types">Not supported.</a></dd>
@@ -1051,7 +1051,7 @@ schema:hasPart:
     </ul>
 
     <p data-tests="manifest.html#html-and-yaml-streams">
-      If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag.
+      If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag. See <a href="#streams">Streams</a> for details.
     </p>
   </section>
 
@@ -1083,22 +1083,24 @@ schema:hasPart:
       -->
     </pre>
 
-    <p class="issue" data-number="63">
-      <a>YAML streams</a> may correspond more directly to
-      [[[RFC7464]]], which are not presently part of the
-      <a data-cite="JSON-LD11#dfn-internal-representation">JSON-LD internal representation</a>.
-      The description here more closely aligns with how JSON-LD
-      interprets <a data-cite="JSON-LD11-API#html-content-algorithms">HTML Scripts</a>.
+    <p class="informative">
+      [[JSON-LD11-API]] defines the
+      <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
+      multiple `&lt;script>` tags with YAML-LD content.
     </p>
 
-    <p>
-      Current specification does not support this feature.
-      Implementations MAY choose, for example, to do any of the following:
+    <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
+      A conformant YAML-LD specification MUST also take this flag in account
+      while parsing a normal YAML-LD document.
     </p>
 
     <ul>
-      <li>Convert each document into a separate JSON-LD document</li>
-      <li>Convert the whole YAML-LD stream into a single JSON-LD array</li>
+      <li>
+        If the flag is `true`, the <a>YAML stream</a> is considered an array, and each document in it is an item in that array, even if there is only one document in the stream;
+      </li>
+      <li>
+        If the flag is `false`, only the first document in the stream will be processed.
+      </li>
     </ul>
 
     <p class="note" title="Interoperability considerations on YAML streams">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1090,7 +1090,7 @@ schema:hasPart:
     </p>
 
     <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
-      A conformant YAML-LD specification MUST also take this flag in account
+      A conformant YAML-LD specification MUST take this flag into account
       while parsing a normal YAML-LD document.
     </p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1071,12 +1071,12 @@ schema:hasPart:
          data-content-type="application/ld+json"
          title="YAML-LD with several documents in one file">
       <!--
-      "@context": https://schema.org
+      "@base": https://schema.org
       "@id": https://w3.org/yaml-ld/
       "@type": WebContent
       name: YAML-LD
       ---
-      "@context": https://schema.org
+      "@base": https://schema.org
       "@id": https://www.w3.org/TR/json-ld11/
       "@type": WebContent
       name: JSON-LD

--- a/spec/index.html
+++ b/spec/index.html
@@ -1096,7 +1096,9 @@ schema:hasPart:
 
     <ul>
       <li>
-        If the flag is `true`, the <a>YAML stream</a> is considered an array, and each document in it is an item in that array, even if there is only one document in the stream;
+        If the flag is `true`, the <a>YAML stream</a> is considered an array,
+        and each document in it is an item in that array, even if there is
+        only one document in the stream;
       </li>
       <li>
         If the flag is `false`, only the first document in the stream will be processed.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1055,6 +1055,58 @@ schema:hasPart:
     </p>
   </section>
 
+
+  <section id="streams">
+    <h2>Streams</h2>
+
+    <p>
+      Every YAML-LD file is a <a>YAML-LD stream</a>
+      and might contain multiple <a>YAML-LD documents</a>,
+      as shown in the example below.
+    </p>
+
+    <pre class="example yaml"
+         data-transform="updateExample"
+         data-result-for="YAML-LD with multiple documents"
+         data-content-type="application/ld+json"
+         title="YAML-LD with several documents in one file">
+      <!--
+      "@context": https://schema.org
+      "@id": https://w3.org/yaml-ld/
+      "@type": WebContent
+      name: YAML-LD
+      ---
+      "@context": https://schema.org
+      "@id": https://www.w3.org/TR/json-ld11/
+      "@type": WebContent
+      name: JSON-LD
+      -->
+    </pre>
+
+    <p class="issue" data-number="63">
+      <a>YAML streams</a> may correspond more directly to
+      [[[RFC7464]]], which are not presently part of the
+      <a data-cite="JSON-LD11#dfn-internal-representation">JSON-LD internal representation</a>.
+      The description here more closely aligns with how JSON-LD
+      interprets <a data-cite="JSON-LD11-API#html-content-algorithms">HTML Scripts</a>.
+    </p>
+
+    <p>
+      Current specification does not support this feature.
+      Implementations MAY choose, for example, to do any of the following:
+    </p>
+
+    <ul>
+      <li>Convert each document into a separate JSON-LD document</li>
+      <li>Convert the whole YAML-LD stream into a single JSON-LD array</li>
+    </ul>
+
+    <p class="note" title="Interoperability considerations on YAML streams">
+      For interoperability considerations on YAML streams,
+      see <a data-cite="I-D.ietf-httpapi-yaml-mediatypes#section-3.2">the relevant section in YAML Media Type</a>.
+    </p>
+  </section>
+
   <section id="iana" class="appendix normative">
     <h2>IANA Considerations</h2>
 
@@ -1336,57 +1388,6 @@ schema:hasPart:
         </li>
       </ul>
     </section>
-  </section>
-
-  <section id="streams" class="informative">
-    <h2>Streams</h2>
-
-    <p>
-      Every YAML-LD file is a <a>YAML-LD stream</a>
-      and might contain multiple <a>YAML-LD documents</a>,
-      as shown in the example below.
-    </p>
-
-    <pre class="example yaml"
-         data-transform="updateExample"
-         data-result-for="YAML-LD with multiple documents"
-         data-content-type="application/ld+json"
-         title="YAML-LD with several documents in one file">
-      <!--
-      "@context": https://schema.org
-      "@id": https://w3.org/yaml-ld/
-      "@type": WebContent
-      name: YAML-LD
-      ---
-      "@context": https://schema.org
-      "@id": https://www.w3.org/TR/json-ld11/
-      "@type": WebContent
-      name: JSON-LD
-      -->
-    </pre>
-
-    <p class="issue" data-number="63">
-      <a>YAML streams</a> may correspond more directly to
-      [[[RFC7464]]], which are not presently part of the
-      <a data-cite="JSON-LD11#dfn-internal-representation">JSON-LD internal representation</a>.
-      The description here more closely aligns with how JSON-LD
-      interprets <a data-cite="JSON-LD11-API#html-content-algorithms">HTML Scripts</a>.
-    </p>
-
-    <p>
-      Current specification does not support this feature.
-      Implementations MAY choose, for example, to do any of the following:
-    </p>
-
-    <ul>
-      <li>Convert each document into a separate JSON-LD document</li>
-      <li>Convert the whole YAML-LD stream into a single JSON-LD array</li>
-    </ul>
-
-    <p class="note" title="Interoperability considerations on YAML streams">
-      For interoperability considerations on YAML streams,
-      see <a data-cite="I-D.ietf-httpapi-yaml-mediatypes#section-3.2">the relevant section in YAML Media Type</a>.
-    </p>
   </section>
 
     <section id="extended-profile" class="informative">

--- a/tests/cases/streams/one-document-out.yamlld
+++ b/tests/cases/streams/one-document-out.yamlld
@@ -1,0 +1,5 @@
+"@base":
+  - https://schema.org/
+"@id": https://w3.org/yaml-ld/
+"@type":
+  - WebContent

--- a/tests/cases/streams/two-documents-in.yamlld
+++ b/tests/cases/streams/two-documents-in.yamlld
@@ -1,0 +1,9 @@
+"@base": https://schema.org/
+"@id": https://w3.org/yaml-ld/
+"@type": WebContent
+name: YAML-LD
+---
+"@base": https://schema.org/
+"@id": https://www.w3.org/TR/json-ld11/
+"@type": WebContent
+name: JSON-LD

--- a/tests/cases/streams/two-documents-out.yamlld
+++ b/tests/cases/streams/two-documents-out.yamlld
@@ -1,0 +1,10 @@
+- "@base":
+    - https://schema.org/
+  "@id": https://w3.org/yaml-ld/
+  "@type":
+    - WebContent
+- "@base":
+    - https://schema.org/
+  "@id": https://www.w3.org/TR/json-ld11/
+  "@type":
+    - WebContent

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -215,6 +215,24 @@
       "option": {"extractAllScripts": true},
       "input": "cases/html/dedent-not-needed.html",
       "expect": "cases/html/stream.yamlld"
+    },
+    {
+      "@id": "#two-documents-from-stream",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "YAML Stream with multiple documents.",
+      "req": "must",
+      "option": {"extractAllScripts": true},
+      "input": "cases/streams/two-documents-in.yamlld",
+      "expect": "cases/streams/two-documents-out.yamlld"
+    },
+    {
+      "@id": "#one-document-from-stream",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "YAML Stream with multiple documents.",
+      "req": "must",
+      "option": {"extractAllScripts": false},
+      "input": "cases/streams/two-documents-in.yamlld",
+      "expect": "cases/streams/one-document-out.yamlld"
     }
   ]
 }


### PR DESCRIPTION
# Why

We do not support YAML Streams, but we already have some support for them within `<script>` tags.

# What

Generalize that support to YAML-LD files too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/133.html" title="Last updated on Apr 4, 2024, 5:57 PM UTC (9f9b6ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/133/1165a89...9f9b6ef.html" title="Last updated on Apr 4, 2024, 5:57 PM UTC (9f9b6ef)">Diff</a>