### PR TITLE
(closing #135) Remove the notion of dedent for HTML `<script>` blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 web/
 !web/.gitkeep
+.python-version

--- a/spec/index.html
+++ b/spec/index.html
@@ -1347,9 +1347,9 @@ schema:hasPart:
 
       <p>The YAML specification states in <a data-cite="YAML#912-document-markers">Document Markers</a> section that `---`, the document separator sequence, must be at the root level of the document, which means indentation level of 0.</p>
 
-      <p>Without the document separator, YAML content inside the `&lt;script>` block can be indented however the author of the document pleases; but the strict rule for indentation of the separator defies that apparent clarity.</p>
+      <p>Aside from the document separator, YAML content inside the `&lt;script>` block can be indented however the author of the document pleases. The strict rule for indentation of the separator is an important exception.</p>
 
-      <p>It is probably best to avoid nesting YAML streams inside `&lt;script>` blocks; create one such block per document instead.</p>
+      <p>It is therefore best to avoid nesting YAML streams inside `&lt;script>` blocks; instead, create one such block per document.</p>
   </section>
 
   <section id="comments-as-whitespace" class="informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1012,7 +1012,7 @@ schema:hasPart:
 
     <p>
       YAML-LD content can be easily embedded in HTML [[HTML]] by placing it
-      in a <code>&lt;script></code> element with the type attribute set to
+      in a <code>&lt;script></code> element with the `type` attribute set to
       `application/ld+yaml`, as illustrated on an example below.
     </p>
 
@@ -1022,33 +1022,18 @@ schema:hasPart:
      title="YAML-LD document embedded in HTML">
     <!--
     <script type="application/ld+yaml">
-    "@context": https://json-ld.org/contexts/person.jsonld
-    "@id": http://dbpedia.org/resource/John_Lennon
-    name: John Lennon
-    born: 1940-10-09
-    spouse: http://dbpedia.org/resource/Cynthia_Lennon
-    ---
-    "@context": https://json-ld.org/contexts/person.jsonld
-    "@id": http://dbpedia.org/resource/Cynthia_Lennon
-    born: 1939-09-10
+      "@context": https://json-ld.org/contexts/person.jsonld
+      "@id": http://dbpedia.org/resource/John_Lennon
+      name: John Lennon
+      born: 1940-10-09
+      spouse: http://dbpedia.org/resource/Cynthia_Lennon
     </script>
     -->
     </pre>
 
     <p data-tests="manifest.html#html-dedent-needed,manifest.html#html-dedent-not-needed">
-      YAML syntax is indentation based. Before processing each `&lt;script>` block with YAML-LD content, YAML-LD processor MUST <em>dedent</em> the body of the block using the following procedure:
+      YAML syntax is indentation based. When processing each `&lt;script>` block with YAML-LD content, YAML-LD processor MUST <em>preserve</em> all space and newline characters in the block content as they are.
     </p>
-
-    <ul>
-      <li>Count the number of <strong>leading spaces</strong> in the first non-empty line of the YAML-LD block, and save that to `dedent_count` variable.</li>
-      <li>
-        For each line of the YAML-LD block,
-        <ul>
-          <li>If the number of leading spaces is less than `dedent_count`, keep the line as-is,</li>
-          <li>Otherwise, remove exactly `dedent_count` leading spaces from the line.</li>
-        </ul>
-      </li>
-    </ul>
 
     <p data-tests="manifest.html#html-and-yaml-streams">
       If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag. See <a href="#streams">Streams</a> for details.
@@ -1330,6 +1315,41 @@ schema:hasPart:
           $type: WebContent
         -->
       </pre>
+
+      <div class="practice">
+        <p class="practicedesc">
+          <span id="bp-avoid-streams-in-html-scripts" class="practicelab">
+            Avoid stuffing more than one YAML document into a single `&lt;script>` HTML tag. Create one tag per document instead.
+          </span>
+        </p>
+      </div>
+
+      <p>Consider the following example.</p>
+
+      <pre class="example yaml"
+       data-transform="updateExample"
+       data-content-type="application/ld+yaml"
+       title="YAML-LD document stream embedded in HTML">
+      <!--
+      <script type="application/ld+yaml">
+        "@context": https://json-ld.org/contexts/person.jsonld
+        "@id": http://dbpedia.org/resource/John_Lennon
+        name: John Lennon
+        born: 1940-10-09
+        spouse: http://dbpedia.org/resource/Cynthia_Lennon
+      ---
+        "@context": https://json-ld.org/contexts/person.jsonld
+        "@id": http://dbpedia.org/resource/Cynthia_Lennon
+        born: 1939-09-10
+      </script>
+      -->
+      </pre>
+
+      <p>The YAML specification states in <a data-cite="YAML#912-document-markers">Document Markers</a> section that `---`, the document separator sequence, must be at the root level of the document, which means indentation level of 0.</p>
+
+      <p>Without the document separator, YAML content inside the `&lt;script>` block can be indented however the author of the document pleases; but the strict rule for indentation of the separator defies that apparent clarity.</p>
+
+      <p>It is probably best to avoid nesting YAML streams inside `&lt;script>` blocks; create one such block per document instead.</p>
   </section>
 
   <section id="comments-as-whitespace" class="informative">
@@ -1358,7 +1378,7 @@ schema:hasPart:
             <li>anchor names</li>
           </ul>
 
-          must not be used to convey application level information
+          must not be used to convey application level information.
         </dd>
       </dl>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1013,7 +1013,7 @@ schema:hasPart:
     <p>
       YAML-LD content can be easily embedded in HTML [[HTML]] by placing it
       in a <code>&lt;script></code> element with the `type` attribute set to
-      `application/ld+yaml`, as illustrated on an example below.
+      `application/ld+yaml`, as illustrated in an example below.
     </p>
 
     <pre class="example yaml"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1032,7 +1032,8 @@ schema:hasPart:
     </pre>
 
     <p data-tests="manifest.html#html-dedent-needed,manifest.html#html-dedent-not-needed">
-      YAML syntax is indentation based. When processing each `&lt;script>` block with YAML-LD content, YAML-LD processor MUST <em>preserve</em> all space and newline characters in the block content as they are.
+      YAML syntax is indentation based. Therefore, when processing each `&lt;script>` block with YAML-LD content,
+      YAML-LD processor MUST preserve the content of the block for YAML parsing <em>as-is</em>, including whitespace characters.
     </p>
 
     <p data-tests="manifest.html#html-and-yaml-streams">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/137.html" title="Last updated on Apr 8, 2024, 7:28 PM UTC (2fd539e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/137/06f0245...2fd539e.html" title="Last updated on Apr 8, 2024, 7:28 PM UTC (2fd539e)">Diff</a>