### PR TITLE
Fixes use of @base in one-document and two-document tests.

### DIFF
--- a/tests/cases/streams/one-document-out.yamlld
+++ b/tests/cases/streams/one-document-out.yamlld
@@ -1,3 +1,3 @@
-- "@base": [https://schema.org/]
-  "@id": https://w3.org/yaml-ld/
-  "@type": [WebContent]
+- "@id": https://w3.org/yaml-ld/
+  "@type":
+    - https://schema.org/WebContent

--- a/tests/cases/streams/two-documents-in.yamlld
+++ b/tests/cases/streams/two-documents-in.yamlld
@@ -1,9 +1,11 @@
-"@base": https://schema.org/
+"@context":
+  "@base": https://schema.org/
 "@id": https://w3.org/yaml-ld/
 "@type": WebContent
 name: YAML-LD
 ---
-"@base": https://schema.org/
+"@context":
+  "@base": https://schema.org/
 "@id": https://www.w3.org/TR/json-ld11/
 "@type": WebContent
 name: JSON-LD

--- a/tests/cases/streams/two-documents-out.yamlld
+++ b/tests/cases/streams/two-documents-out.yamlld
@@ -1,10 +1,6 @@
-- "@base":
-    - https://schema.org/
-  "@id": https://w3.org/yaml-ld/
+- "@id": https://w3.org/yaml-ld/
   "@type":
-    - WebContent
-- "@base":
-    - https://schema.org/
-  "@id": https://www.w3.org/TR/json-ld11/
+    - https://schema.org/WebContent
+- "@id": https://www.w3.org/TR/json-ld11/
   "@type":
-    - WebContent
+    - https://schema.org/WebContent


### PR DESCRIPTION
Fixes some syntax issues: `@base` must be within `@context`.