### PR TITLE
Add `#mixed-script-types` test

### DIFF
--- a/tests/cases/html/mixed-types.html
+++ b/tests/cases/html/mixed-types.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+    <script type="application/ld+yaml">
+        "@context": https://json-ld.org/contexts/person.jsonld
+        "@id": https://dbpedia.org/resource/John_Lennon
+        name: John Lennon
+        born: 1940-10-09
+        spouse:
+          - https://dbpedia.org/resource/Yoko_Ono
+          - https://dbpedia.org/resource/Cynthia_Lennon
+---
+        "@context": https://json-ld.org/contexts/person.jsonld
+        "@id": https://dbpedia.org/resource/Yoko_Ono
+        born: 1933-02-18
+    </script>
+</head>
+<body>
+<h1>Hi!</h1>
+
+<script type="application/ld+json">
+{
+  "@context": "https://json-ld.org/contexts/person.jsonld",
+  "@id": "https://dbpedia.org/resource/Cynthia_Lennon",
+  "born": "1939-09-10"
+}
+</script>
+</body>
+</html>

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -199,6 +199,15 @@
       "expect": "cases/html/stream.yamlld"
     },
     {
+      "@id": "#mixed-script-types",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "YAML Stream with multiple documents embedded into HTML, having JSON-LD and YAML-LD documents in them.",
+      "req": "must",
+      "option": {"extractAllScripts": true},
+      "input": "cases/html/mixed-types.html",
+      "expect": "cases/html/stream.yamlld"
+    },
+    {
       "@id": "#html-dedent-needed",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "YAML Stream with multiple documents embedded into HTML.",


### PR DESCRIPTION
# Why

It is feasible that one HTML document would contain both `application/ld+yaml` and `application/ld+json` `<script>` tags.

# What

Create a test for that.