### PR TITLE
Fix: #156. Update media type registration information.

### DIFF
--- a/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
+++ b/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
@@ -904,7 +904,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </style>
 <script id="initialUserConfig" type="application/json">{
   "specStatus": "CG-FINAL",
-  "copyrightStart": "2020",
+  "copyrightStart": "2020"
   "shortName": "yaml-ld",
   "edDraftURI": "https://json-ld.github.io/yaml-ld/",
   "latestVersion": "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/",
@@ -1871,7 +1871,7 @@ author:
         </dl>
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>
-      <dd>Philippe Le Hégaret &lt;plh@w3.org&gt;</dd>
+      <dd>W3C JSON-LD Working Group &lt;public-json-ld-wg@w3.org&gt;</dd>
       <dt>Intended usage:</dt>
       <dd>Common</dd>
       <dt>Restrictions on usage:</dt>

--- a/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
+++ b/publication-snapshots/CG-FINAL-2023-12-06/Overview.html
@@ -904,7 +904,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </style>
 <script id="initialUserConfig" type="application/json">{
   "specStatus": "CG-FINAL",
-  "copyrightStart": "2020"
+  "copyrightStart": "2020",
   "shortName": "yaml-ld",
   "edDraftURI": "https://json-ld.github.io/yaml-ld/",
   "latestVersion": "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/",
@@ -1871,7 +1871,7 @@ author:
         </dl>
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>
-      <dd>W3C JSON-LD Working Group &lt;public-json-ld-wg@w3.org&gt;</dd>
+      <dd>Philippe Le Hégaret &lt;plh@w3.org&gt;</dd>
       <dt>Intended usage:</dt>
       <dd>Common</dd>
       <dt>Restrictions on usage:</dt>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1220,7 +1220,7 @@ schema:hasPart:
         </dl>
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>
-      <dd>Philippe Le Hégaret &lt;plh@w3.org&gt;</dd>
+      <dd>W3C JSON-LD Working Group &lt;public-json-ld-wg@w3.org&gt;</dd>
       <dt>Intended usage:</dt>
       <dd>Common</dd>
       <dt>Restrictions on usage:</dt>

--- a/spec/index.html
+++ b/spec/index.html
@@ -48,17 +48,6 @@
           "Philippe Le Hegaret",
         ],
       },
-
-      "YAML": {
-        title: "YAML Ain’t Markup Language (YAML™) version 1.2.2",
-        href: "https://yaml.org/spec/1.2.2/",
-        date: "2021-10-01",
-        authors: [
-          "Oren Ben-Kiki",
-          "Clark Evans",
-          "Ingy döt Net"
-        ]
-      }
     },
 
     // Cross-reference definitions

--- a/spec/index.html
+++ b/spec/index.html
@@ -32,19 +32,6 @@
     }],
 
     localBiblio: {
-      "RFC9512": {
-        title: "YAML Media Type",
-        href: "https://www.rfc-editor.org/rfc/rfc9512",
-        publisher: "IETF",
-        date: "2022-02-14",
-        status: "Informational",
-        authors: [
-          "Roberto Polli",
-          "Erik Wilde",
-          "Eemeli Aro"
-        ]
-      },
-
       "json-ld-bp": {
         title: "JSON-LD Best Practices",
         href: "https://w3c.github.io/json-ld-bp/",

--- a/spec/index.html
+++ b/spec/index.html
@@ -1046,7 +1046,7 @@ schema:hasPart:
     <p>
       For general interoperability considerations on the serialization of
       <a>JSON documents</a> in [[YAML]], see YAML
-      and the Interoperability consideration of <code>+yaml</code> structured syntax suffix.
+      and the Interoperability considerations of the <code>+yaml</code> structured syntax suffix.
     </p>
     <p>
       The YAML-LD format and the media type registration are not restricted to a specific

--- a/spec/index.html
+++ b/spec/index.html
@@ -32,12 +32,12 @@
     }],
 
     localBiblio: {
-      "I-D.ietf-httpapi-yaml-mediatypes": {
+      "RFC9512": {
         title: "YAML Media Type",
-        href: "https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-03.html",
+        href: "https://www.rfc-editor.org/rfc/rfc9512",
         publisher: "IETF",
-        date: "2022-08-05",
-        status: "WG Document",
+        date: "2022-02-14",
+        status: "Informational",
         authors: [
           "Roberto Polli",
           "Erik Wilde",
@@ -355,7 +355,7 @@ schema:hasPart:
     <p>
       Since YAML is more expressive than JSON,
       both in the available data types and in the document structure
-      (see [[I-D.ietf-httpapi-yaml-mediatypes]]),
+      (see [[RFC9512]]),
       this document identifies constraints on YAML
       such that any <a>YAML-LD document</a> can be represented in JSON-LD.
     </p>
@@ -902,7 +902,7 @@ schema:hasPart:
       </p>
 
       <p>
-        See Interoperability considerations of [[I-D.ietf-httpapi-yaml-mediatypes]]
+        See Interoperability considerations of "+yaml" structured syntax suffix
         for more details.
       </p>
     </section>
@@ -1036,8 +1036,8 @@ schema:hasPart:
   <section id="sec" class="informative">
     <h2>Security Considerations</h2>
 
-    <p>See <a data-cite="JSON-LD11#iana-security">Security considerations in JSON-LD 1.1</a>.
-      Also, see the YAML media type registration.</p>
+    <p>See <a data-cite="JSON-LD11#iana-security">Security considerations in JSON-LD 1.1</a>
+       and <code>+yaml</code> structured syntax suffix.</p>
   </section>
 
   <section id="int" class="informative">
@@ -1046,7 +1046,7 @@ schema:hasPart:
     <p>
       For general interoperability considerations on the serialization of
       <a>JSON documents</a> in [[YAML]], see YAML
-      and the Interoperability consideration of <code>application/yaml</code> [[I-D.ietf-httpapi-yaml-mediatypes]].
+      and the Interoperability consideration of <code>+yaml</code> structured syntax suffix.
     </p>
     <p>
       The YAML-LD format and the media type registration are not restricted to a specific
@@ -1146,7 +1146,7 @@ schema:hasPart:
 
     <p class="note" title="Interoperability considerations on YAML streams">
       For interoperability considerations on YAML streams,
-      see <a data-cite="I-D.ietf-httpapi-yaml-mediatypes#section-3.2">the relevant section in YAML Media Type</a>.
+      see <a data-cite="RFC9512#section-3.2">the relevant section in YAML Media Type</a>.
     </p>
   </section>
 
@@ -1212,7 +1212,7 @@ schema:hasPart:
         </dl>
       </dd>
       <dt>Encoding considerations:</dt>
-      <dd>See <a data-cite="I-D.ietf-httpapi-yaml-mediatypes#">YAML media type</a>.</dd>
+      <dd>Same as <code>+yaml</code>.</dd>
       <dt id="iana-security">Security considerations:</dt>
       <dd>See <a href="#sec" class="sectionRef"></a>.</dd>
       <dt>Interoperability considerations:</dt>
@@ -1226,8 +1226,10 @@ schema:hasPart:
       <dt>Additional information:</dt>
       <dd>
         <dl>
+          <dt>Deprecated alias names for this type:</dt>
+          <dd>N/A</code></dd>
           <dt>Magic number(s):</dt>
-          <dd>See <code>application/yaml</code></dd>
+          <dd>Same as <code>application/yaml</code></dd>
           <dt>File extension(s):</dt>
           <dd>
             <ul>
@@ -1236,7 +1238,9 @@ schema:hasPart:
             </ul>
           </dd>
           <dt>Macintosh file type code(s):</dt>
-          <dd>TEXT</dd>
+          <dd>Same as <code>application/yaml</code></dd>
+          <dt>Windows Clipboard Name:</dt>
+          <dd>Same as <code>application/yaml</code></dd>
         </dl>
       </dd>
       <dt>Person &amp; email address to contact for further information:</dt>


### PR DESCRIPTION
## This PR

- update references to RFC9512
- minor fixes to the media type registration data.

fixes #156.

## Question

IMHO we can ask IESG / Mediaman if this doc is enough for the registration. If needed, I can investigate further.

If the fragment identification stuff is not clear, we could add a couple of examples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/pull/157.html" title="Last updated on Nov 14, 2024, 4:04 PM UTC (fa2cc75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/json-ld/yaml-ld/157/04674fe...fa2cc75.html" title="Last updated on Nov 14, 2024, 4:04 PM UTC (fa2cc75)">Diff</a>