### PR TITLE
#20 Reference exact test suite versions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -579,17 +579,17 @@ schema:hasPart:
 
     <ul>
       <li>
-        <a href="https://json-ld.github.io/yaml-ld/tests/">YAML-LD tests</a>;
+        <a href="https://w3c.github.io/yaml-ld/tests/">YAML-LD tests</a> (this specification);
       </li>
       <li>
-        <a href="https://w3c.github.io/json-ld-api/tests/">JSON-LD API tests</a>;
+        <a href="https://w3c.github.io/json-ld-api/tests/">JSON-LD API tests</a> [[JSON-LD11-API]];
       </li>
       <li>
-        <a href="https://w3c.github.io/json-ld-framing/tests/">JSON-LD Framing tests</a>,
+        <a href="https://w3c.github.io/json-ld-framing/tests/">JSON-LD Framing tests</a> [[JSON-LD11-FRAMING]],
       </li>
     </ul>
 
-    <p>...with the exclusion of the test cases where:</p>
+    <p>...disregarding the test cases where:</p>
 
     <ul>
       <li>
@@ -598,8 +598,8 @@ schema:hasPart:
     </ul>
 
     <p class="note">
-      Since YAML is a superset of JSON, testing a YAML-LD against
-      tests cases from JSON-LD test suites should be trivial.
+      Since <a href="#json-vs-yaml">YAML is a superset of JSON</a>, testing a YAML-LD implementation against
+      test cases from JSON-LD test suites should be trivial.
     </p>
   </section>
 </section>


### PR DESCRIPTION
Issue #20 calls for adding tests. We actually have a section about Test Suites in the spec; I believe our approach to testing implementations of YAML-LD makes sense, but I added references to exact spec versions and changed the wording. I hope this will permit us to close that issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/168.html" title="Last updated on Feb 15, 2026, 4:40 PM UTC (f617832)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/168/4ec9705...f617832.html" title="Last updated on Feb 15, 2026, 4:40 PM UTC (f617832)">Diff</a>