### PR TITLE
Fix stream expected outputs for name expansion

### DIFF
--- a/tests/cases/streams/one-document-out.yamlld
+++ b/tests/cases/streams/one-document-out.yamlld
@@ -1,3 +1,5 @@
 - "@id": https://w3.org/yaml-ld/
   "@type":
     - https://schema.org/WebContent
+  https://schema.org/name:
+    - "@value": YAML-LD

--- a/tests/cases/streams/two-documents-out.yamlld
+++ b/tests/cases/streams/two-documents-out.yamlld
@@ -1,6 +1,10 @@
 - "@id": https://w3.org/yaml-ld/
   "@type":
     - https://schema.org/WebContent
+  https://schema.org/name:
+    - "@value": YAML-LD
 - "@id": https://www.w3.org/TR/json-ld11/
   "@type":
     - https://schema.org/WebContent
+  https://schema.org/name:
+    - "@value": JSON-LD


### PR DESCRIPTION
## Summary

Adjust the stream expected outputs to include the expanded `https://schema.org/name` values.