### PR TITLE
Clarify YAML-LD anchor and alias handling

### DIFF
--- a/extended-profile/index.html
+++ b/extended-profile/index.html
@@ -597,10 +597,9 @@
 
         <p id="aa-json-aliases" data-tests="manifest.html#aa-cycles-1-positive">
           When processing using the <a>YAML-LD Basic profile</a>,
-          documents MUST NOT contain <a>alias nodes</a>;
-          otherwise, a
-          <a data-link-for="YamlLdErrorCode">profile-error</a>
-          error has been detected and processing is aborted.
+          <a>alias nodes</a> are resolved by value to their target nodes.
+          Anchor names and alias structure are not retained in the
+          JSON-LD representation.
         </p>
 
 
@@ -912,9 +911,9 @@
               If an <a>alias node</a> is encountered when processing the
               <a>YAML representation graph</a>
               and the {{JsonLdOptions/processingMode}} option is not equal to `yaml-ld-extended`,
-              the <a>YAML-LD Basic profile</a> has been selected.
-              A <a data-link-for="YamlLdErrorCode">profile-error</a>
-              error has been detected and processing MUST be aborted.
+              the conversion result is the value of the target node,
+              as described in the
+              <a href="#aa-json-aliases">Basic profile alias handling</a>.
             </p>
 
             <p id="cir-alias-cycles" data-tests="
@@ -1141,8 +1140,9 @@
             </p>
 
             <p>
-              Although YAML-LD documents MAY include <a>node anchors</a>,
-              documents MUST NOT use <a>alias nodes</a>.
+              YAML-LD documents MAY include <a>node anchors</a> and
+              <a>alias nodes</a>, as long as dereferencing these aliases
+              does not result in a loop.
             </p>
 
             <p>
@@ -1177,7 +1177,7 @@
             </p>
 
             <p>
-              YAML-LD docucments MAY use <a>alias nodes</a>,
+              YAML-LD documents MAY use <a>alias nodes</a>,
               as long as dereferencing these aliases does not result in a loop.
             </p>
 

--- a/index.html
+++ b/index.html
@@ -969,6 +969,15 @@ schema:hasPart:
       alias nodes MUST be resolved by value to their target nodes.
     </p>
 
+    <aside class="note" title="Anchors and aliases are YAML serialization features">
+      <p>
+        Converting a YAML-LD document with anchors or aliases to JSON-LD,
+        and then serializing it back to YAML-LD, preserves the semantic data
+        but is not expected to recreate the original anchors, aliases,
+        or anchor names.
+      </p>
+    </aside>
+
     <p>
       The <a>YAML-LD document</a> in the following example
       contains alias nodes for the `{"@id": "country:US"}` object:


### PR DESCRIPTION
## Summary

- Clarifies that anchors and aliases remain valid YAML-LD but do not round-trip as YAML syntax through JSON-LD.
- Aligns the Extended Profile text so Basic profile alias handling resolves aliases instead of treating them as profile errors.

Closes #195.

## Validation

- make spec
- make extended-profile (exits 0; reports existing missing testSuiteURI ReSpec warning)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/196.html" title="Last updated on Apr 25, 2026, 5:10 PM UTC (42517ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/196/7794d51...42517ac.html" title="Last updated on Apr 25, 2026, 5:10 PM UTC (42517ac)">Diff</a>