### PR TITLE
[#194] Align YAML-LD feature comparison

### DIFF
--- a/data/json-vs-yaml.yamlld
+++ b/data/json-vs-yaml.yamlld
@@ -1,148 +1,292 @@
 "@context":
   - https://json-ld.org/contexts/dollar-convenience.jsonld
   - "@base": https://w3c.github.io/
+    "$": rdfs:label
+    comparison:
+      "@id": https://w3c.github.io/yaml-ld/data/json-vs-yaml.yamlld#
+      "@prefix": true
+    json: comparison:json
+    yaml: comparison:yaml
+    yamlld: comparison:yaml-ld
+    yaml-ld:
+      "@id": https://w3c.github.io/yaml-ld/#
+      "@prefix": true
+    rfc8259:
+      "@id": https://www.rfc-editor.org/rfc/rfc8259#
+      "@prefix": true
+    yaml-spec:
+      "@id": https://yaml.org/spec/1.2.2/#
+      "@prefix": true
     rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
     rdfs: http://www.w3.org/2000/01/rdf-schema#
     prov: http://www.w3.org/ns/prov#
+    prov:wasDerivedFrom:
+      "@type": "@id"
 
 $id: JSONOrYAMLFeature
+$: JSON vs YAML comparison
+$included:
+  - $id: comparison:json
+    $: Supported by JSON
+  - $id: comparison:yaml
+    $: Supported by YAML
+  - $id: comparison:yaml-ld
+    $: Supported by YAML-LD
+  - $id: prov:value
+    $: value
+  - $id: prov:wasDerivedFrom
+    $: was derived from
 $reverse:
   rdf:type:
     - rdfs:label: UTF-8
-      $type: Encoding
+      rdf:type: &encoding
+        $id: yaml-ld:encoding
+        $: Encoding
       json:
-        - prov:value: yes
-          prov:wasDerivedFrom: JSON#section-8.1
+        - &json-encoding
+          prov:value: true
+          prov:wasDerivedFrom:
+            $id: rfc8259:section-8.1
+            $: RFC 8259 section 8.1 Character Encoding
       yaml:
-        - prov:value: yes
-          prov:wasDerivedFrom: YAML#52-character-encodings
+        - &yaml-encoding
+          prov:value: true
+          prov:wasDerivedFrom:
+            $id: yaml-spec:52-character-encodings
+            $: YAML 5.2 Character Encodings
+      yamlld: &yamlld-encoding
+        prov:value: true
+        prov:wasDerivedFrom: yaml-ld:encoding
 
     - rdfs:label: UTF-16
+      rdf:type: *encoding
       json:
-        - prov:value: no
-          prov:wasDerivedFrom: JSON#section-8.1
+        - <<: *json-encoding
+          prov:value: false
       yaml:
-        - prov:value: yes
-          prov:wasDerivedFrom: YAML#52-character-encodings
+        - *yaml-encoding
+      yamlld:
+        <<: *yamlld-encoding
+        prov:value: false
 
     - rdfs:label: UTF-32
+      rdf:type: *encoding
       json:
-        - prov:value: no
-          prov:wasDerivedFrom: JSON#section-8.1
+        - <<: *json-encoding
+          prov:value: false
       yaml:
-        - prov:value: yes
-          prov:wasDerivedFrom: YAML#52-character-encodings
+        - *yaml-encoding
+      yamlld:
+        <<: *yamlld-encoding
+        prov:value: false
 
-    - rdfs:label: "<code>{}</code> object"
+    - rdfs:label: object
       rdf:type:
         $id: native-data-types
         rdfs:label: Native data types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-4
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: rfc8259:section-4
+          $: RFC 8259 section 4 Objects
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#3211-nodes
+        prov:value: true
+        prov:wasDerivedFrom: &yaml-nodes
+          $id: yaml-spec:3211-nodes
+          $: YAML 3.2.1.1 Nodes
+      yamlld:
+        prov:value: true
 
-    - rdfs:label: "<code>[]</code> array"
+    - rdfs:label: array
       $type: native-data-types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-5
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: rfc8259:section-5
+          $: RFC 8259 section 5 Arrays
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#3211-nodes
+        prov:value: true
+        prov:wasDerivedFrom: *yaml-nodes
+      yamlld:
+        prov:value: true
 
     - rdfs:label: string
       $type: native-data-types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-7
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: rfc8259:section-7
+          $: RFC 8259 section 7 Strings
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#3211-nodes
+        prov:value: true
+        prov:wasDerivedFrom: *yaml-nodes
+      yamlld:
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:scalar-value-types
+          $: Scalar Value Types
 
     - rdfs:label: number
       $type: native-data-types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-6
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: rfc8259:section-6
+          $: RFC 8259 section 6 Numbers
       yaml:
         - prov:value: integer
-          prov:wasDerivedFrom: YAML#10213-integer
+          prov:wasDerivedFrom:
+            $id: yaml-spec:10213-integer
+            $: YAML 10.2.1.3 Integer
         - prov:value: floating point
-          prov:wasDerivedFrom: YAML#10214-floating-point
+          prov:wasDerivedFrom:
+            $id: yaml-spec:10214-floating-point
+            $: YAML 10.2.1.4 Floating Point
+      yamlld:
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:scalar-value-types
+          $: Scalar Value Types
 
     - rdfs:label: bool
       $type: native-data-types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-3
+        prov:value: true
+        prov:wasDerivedFrom: &rfc8259-section-3
+          $id: rfc8259:section-3
+          $: RFC 8259 section 3 Values
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#10212-boolean
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:10212-boolean
+          $: YAML 10.2.1.2 Boolean
+      yamlld:
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:scalar-value-types
+          $: Scalar Value Types
 
-    - rdfs:label: null
+    - rdfs:label: "null"
       $type: native-data-types
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-3
+        prov:value: true
+        prov:wasDerivedFrom: *rfc8259-section-3
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#10211-null
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:10211-null
+          $: YAML 10.2.1.1 Null
+      yamlld:
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:scalar-value-types
+          $: Scalar Value Types
 
     - rdfs:label: Delimited strings, arrays, objects
       rdf:type:
         $id: features
         rdfs:label: Features
       json:
-        prov:value: yes
-        prov:wasDerivedFrom: JSON#section-4
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: rfc8259:section-4
+          $: RFC 8259 section 4 Objects
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#chapter-7-flow-style-productions
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:chapter-7-flow-style-productions
+          $: YAML Chapter 7 Flow Style Productions
+      yamlld:
+        prov:value: true
 
     - rdfs:label: Punctuation-free strings, arrays, objects
       $type: features
-      json: no
+      json: false
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#chapter-8-block-style-productions
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:chapter-8-block-style-productions
+          $: YAML Chapter 8 Block Style Productions
+      yamlld:
+        prov:value: true
 
     - rdfs:label: Custom types
       $type: features
-      json: no
+      json: false
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#tags
-
-    - rdfs:label: Cycles
-      $type: features
-      json: no
-      yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#321-representation-graph
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:tags
+          $: YAML 6.9.2 Node Tags
+      yamlld:
+        prov:value: Core Schema only
+        prov:wasDerivedFrom:
+          $id: yaml-ld:node-tags
+          $: Node Tags
 
     - rdfs:label: Documents per file
       json: 1
       yaml:
         prov:value: ⩾ 1
-        prov:wasDerivedFrom: YAML stream
+        prov:wasDerivedFrom:
+          $id: yaml-spec:streams
+          $: YAML 9.1 Streams
+      yamlld:
+        prov:value: ⩾ 1 (depending on `extractAllScripts` flag, see Stream handling)
+        prov:wasDerivedFrom:
+          $id: yaml-ld:streams
+          $: Stream handling
 
     - rdfs:label: Comments
-      json: no
+      json: false
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#3233-comments
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:3233-comments
+          $: YAML 3.2.3.3 Comments
+      yamlld:
+        $: ✅ Treated as Whitespace
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:comments
+          $: Comments
 
     - rdfs:label: Anchors & aliases
-      json: no
+      json: false
       yaml:
-        prov:value: yes
-        prov:wasDerivedFrom: YAML#3222-anchors-and-aliases
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:3222-anchors-and-aliases
+          $: YAML 3.2.2.2 Anchors and Aliases
+      yamlld:
+        $: ✅ Anchor names do not bear semantic information
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-ld:anchors-aliases
+          $: Anchors and Aliases
+
+    - rdfs:label: Cycles
+      $type: features
+      json: false
+      yaml:
+        prov:value: true
+        prov:wasDerivedFrom:
+          $id: yaml-spec:321-representation-graph
+          $: YAML 3.2.1 Representation Graph
+      yamlld:
+        $: ❌ Not permitted
+        prov:value: false
+        prov:wasDerivedFrom:
+          $id: yaml-ld:anchors-aliases
+          $: Anchors and Aliases
 
     - rdfs:label: Mapping key types
       json: string
       yaml:
         prov:value: Any type representable in YAML, from strings to mappings
-        prov:wasDerivedFrom: YAML#3211-nodes
+        prov:wasDerivedFrom: *yaml-nodes
+      yamlld:
+        prov:value: string
+        prov:wasDerivedFrom:
+          $id: yaml-ld:mapping-key-types
+          $: Mapping Key Types

--- a/index.html
+++ b/index.html
@@ -669,51 +669,58 @@ schema:hasPart:
           <th>Features</th>
           <th>[[JSON]]</th>
           <th>[[YAML]]</th>
+          <th>YAML-LD</th>
         </tr>
         </thead>
         <tbody>
         <tr>
-          <th colspan="3">Allowed encodings</th>
+          <th colspan="4">Allowed encodings</th>
         </tr>
 
         <tr>
           <th>UTF-8</th>
           <td><a data-cite="JSON#section-8.1">✅</a></td>
           <td><a data-cite="YAML#52-character-encodings">✅</a></td>
+          <td><a href="#encoding">✅</a></td>
         </tr>
 
         <tr>
           <th>UTF-16</th>
           <td><a data-cite="JSON#section-8.1">❌</a></td>
           <td><a data-cite="YAML#52-character-encodings">✅</a></td>
+          <td><a href="#encoding">❌</a></td>
         </tr>
 
         <tr>
           <th>UTF-32</th>
           <td><a data-cite="JSON#section-8.1">❌</a></td>
           <td><a data-cite="YAML#52-character-encodings">✅</a></td>
+          <td><a href="#encoding">❌</a></td>
         </tr>
 
         <tr>
-          <th colspan="3">Native data types</th>
+          <th colspan="4">Native data types</th>
         </tr>
 
         <tr>
           <th><code>{}</code> object</th>
           <td><a data-cite="JSON#section-4">✅</a></td>
           <td><a data-cite="YAML#3211-nodes">✅</a></td>
+          <td>✅</td>
         </tr>
 
         <tr>
           <th><code>[]</code> array</th>
           <td><a data-cite="JSON#section-5">✅</a></td>
           <td><a data-cite="YAML#3211-nodes">✅</a></td>
+          <td>✅</td>
         </tr>
 
         <tr>
           <th>string</th>
           <td><a data-cite="JSON#section-7">✅</a></td>
           <td><a data-cite="YAML#3211-nodes">✅</a></td>
+          <td><a href="#scalar-value-types">✅</a></td>
         </tr>
 
         <tr>
@@ -726,63 +733,74 @@ schema:hasPart:
             <br>
             <a data-cite="YAML#10214-floating-point">floating
             point</a></td>
+          <td><a href="#scalar-value-types">✅</a></td>
         </tr>
 
         <tr>
           <th>bool</th>
           <td><a data-cite="JSON#section-3">✅</a></td>
           <td><a data-cite="YAML#10212-boolean">✅</a></td>
+          <td><a href="#scalar-value-types">✅</a></td>
         </tr>
 
         <tr>
           <th>null</th>
           <td><a data-cite="JSON#section-3">✅</a></td>
           <td><a data-cite="YAML#10211-null">✅</a></td>
+          <td><a href="#scalar-value-types">✅</a></td>
         </tr>
 
         <tr>
-          <th colspan="3">Features</th>
+          <th colspan="4">Features</th>
         </tr>
 
         <tr>
           <th>Delimited strings, arrays, objects</th>
           <td><a data-cite="JSON#section-4">✅</a></td>
           <td><a data-cite="YAML#chapter-7-flow-style-productions">✅</a></td>
+          <td>✅</td>
         </tr>
 
         <tr>
           <th>Punctuation-free strings, arrays, objects</th>
           <td>❌</td>
           <td><a data-cite="YAML#chapter-8-block-style-productions">✅</a></td>
+          <td>✅</td>
         </tr>
 
         <tr>
           <th>Custom types</th>
           <td>❌</td>
           <td>✅ via <a data-cite="YAML#tags">tags</a></td>
+          <td><a href="#node-tags">Core Schema only</a></td>
         </tr>
 
-        <tr>
-          <th>Cycles</th>
-          <td>❌</td>
-          <td><a data-cite="YAML#321-representation-graph">✅</a></td>
-        </tr>
         <tr>
           <th>Documents per file</th>
           <td>1</td>
           <td>⩾ 1 via <a>YAML stream</a></td>
+          <td>⩾ 1 (depending on <code>extractAllScripts</code> flag, see <a href="#streams">Stream handling</a>)</td>
         </tr>
 
         <tr>
           <th>Comments</th>
           <td>❌</td>
           <td><a data-cite="YAML#3233-comments">✅</a></td>
+          <td>✅ <a href="#comments">Treated as Whitespace</a></td>
         </tr>
 
         <tr>
           <th>Anchors & aliases</th>
           <td>❌</td>
           <td><a data-cite="YAML#3222-anchors-and-aliases">✅</a></td>
+          <td>✅ <a href="#anchors-aliases">Anchor names do not bear semantic information</a></td>
+        </tr>
+
+        <tr>
+          <th>Cycles</th>
+          <td>❌</td>
+          <td><a data-cite="YAML#321-representation-graph">✅</a></td>
+          <td><a href="#anchors-aliases">❌ Not permitted</a></td>
         </tr>
 
         <tr>
@@ -791,6 +809,7 @@ schema:hasPart:
           <td>
             <a data-cite="YAML#3211-nodes">Any type representable in YAML</a>, from strings to mappings
           </td>
+          <td><a href="#mapping-key-types"><code>string</code></a></td>
         </tr>
         </tbody>
       </table>
@@ -871,41 +890,6 @@ schema:hasPart:
 
   <section id="core-requirements" class="normative">
     <h2>Core Requirements</h2>
-
-    <section id="supported-yaml-features" class="informative">
-      <h2>YAML features supported by YAML-LD</h2>
-
-      <dl>
-        <dt>Encoding</dt>
-        <dd>UTF-8 <a href="#encoding">only</a>.</dd>
-
-        <dt>Native data types</dt>
-        <dd>Every native data type that the YAML-LD parser supports.</dd>
-
-        <dt>Tags</dt>
-        <dd>Ignored.</dd>
-
-        <dt>Comments</dt>
-        <dd><a href="#comments">Treated as whitespace</a>.</dd>
-
-        <dt>Anchors & aliases</dt>
-        <dd>Resolved by YAML parser. Anchors & alias names are ignored.</dd>
-
-        <dt>Cycles defined using anchors & aliases</dt>
-        <dd>Not permitted.</dd>
-
-        <dt>YAML Streams</dt>
-        <dd>Treated identically to arrays.</dd>
-
-        <dt>Mapping key types other than <code>string</code></dt>
-        <dd><a href="#mapping-key-types">Not supported.</a></dd>
-      </dl>
-
-      <p>
-        Perspectives for support of the additional YAML features are analyzed in
-        [[yaml-ld-extended-profile]] informative addendum to this specification.
-      </p>
-    </section>
 
     <section id="encoding">
     <h2>Encoding</h2>
@@ -1163,6 +1147,12 @@ schema:hasPart:
         YAML-LD processors MUST NOT perform such conversion and MUST treat these values as strings.
       </p>
 
+      <p id="node-tags">
+        YAML-LD does not assign additional JSON-LD meaning to <a>node tags</a>
+        beyond the scalar type resolution defined by the
+        <a data-cite="YAML#103-core-schema">YAML Core Schema</a>.
+      </p>
+
       <aside class="note" title="Core Schema type resolution">
         <p>
           The following table summarizes scalar type resolution per the
@@ -1230,6 +1220,61 @@ schema:hasPart:
           </tbody>
         </table>
       </aside>
+    </section>
+
+    <section id="streams">
+      <h2>Streams</h2>
+
+      <p>
+        Every YAML-LD file is a <a>YAML-LD stream</a>
+        and might contain multiple <a>YAML-LD documents</a>,
+        as shown in the example below.
+      </p>
+
+      <pre class="example yaml"
+           data-transform="updateExample"
+           data-result-for="YAML-LD with multiple documents"
+           data-content-type="application/ld+json"
+           title="YAML-LD with several documents in one file">
+      <!--
+      "@base": https://schema.org
+      "@id": https://w3c.github.io/yaml-ld/
+      "@type": WebContent
+      name: YAML-LD
+      ---
+      "@base": https://schema.org
+      "@id": https://www.w3.org/TR/json-ld11/
+      "@type": WebContent
+      name: JSON-LD
+      -->
+    </pre>
+
+      <p class="informative">
+        [[JSON-LD11-API]] defines the
+        <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
+        multiple `&lt;script>` tags with YAML-LD content.
+      </p>
+
+      <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
+        A conformant YAML-LD specification MUST take this flag into account
+        while parsing a normal YAML-LD document.
+      </p>
+
+      <ul>
+        <li>
+          If the flag is `true`, the <a>YAML stream</a> is considered an array,
+          and each document in it is an item in that array, even if there is
+          only one document in the stream;
+        </li>
+        <li>
+          If the flag is `false`, only the first document in the stream will be processed.
+        </li>
+      </ul>
+
+      <p class="note" title="Interoperability considerations on YAML streams">
+        For interoperability considerations on YAML streams,
+        see <a data-cite="RFC9512#section-3.2">the relevant section in YAML Media Type</a>.
+      </p>
     </section>
 
     <section id="json-literals" class="informative">
@@ -1395,62 +1440,6 @@ enum YamlLdErrorCode {
 
     <p data-tests="manifest.html#html-and-yaml-streams">
       If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag. See <a href="#streams">Streams</a> for details.
-    </p>
-  </section>
-
-
-  <section id="streams">
-    <h2>Streams</h2>
-
-    <p>
-      Every YAML-LD file is a <a>YAML-LD stream</a>
-      and might contain multiple <a>YAML-LD documents</a>,
-      as shown in the example below.
-    </p>
-
-    <pre class="example yaml"
-         data-transform="updateExample"
-         data-result-for="YAML-LD with multiple documents"
-         data-content-type="application/ld+json"
-         title="YAML-LD with several documents in one file">
-      <!--
-      "@base": https://schema.org
-      "@id": https://w3c.github.io/yaml-ld/
-      "@type": WebContent
-      name: YAML-LD
-      ---
-      "@base": https://schema.org
-      "@id": https://www.w3.org/TR/json-ld11/
-      "@type": WebContent
-      name: JSON-LD
-      -->
-    </pre>
-
-    <p class="informative">
-      [[JSON-LD11-API]] defines the
-      <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
-      multiple `&lt;script>` tags with YAML-LD content.
-    </p>
-
-    <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
-      A conformant YAML-LD specification MUST take this flag into account
-      while parsing a normal YAML-LD document.
-    </p>
-
-    <ul>
-      <li>
-        If the flag is `true`, the <a>YAML stream</a> is considered an array,
-        and each document in it is an item in that array, even if there is
-        only one document in the stream;
-      </li>
-      <li>
-        If the flag is `false`, only the first document in the stream will be processed.
-      </li>
-    </ul>
-
-    <p class="note" title="Interoperability considerations on YAML streams">
-      For interoperability considerations on YAML streams,
-      see <a data-cite="RFC9512#section-3.2">the relevant section in YAML Media Type</a>.
     </p>
   </section>
 


### PR DESCRIPTION
Closes #194.

This PR folds YAML-LD feature support into the JSON vs YAML comparison table, removes the duplicate YAML feature summary, and updates the YAML-LD data version of the comparison table with labeled references and machine-readable support values.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/198.html" title="Last updated on Apr 26, 2026, 2:58 PM UTC (25b7c05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/198/a7733a0...25b7c05.html" title="Last updated on Apr 26, 2026, 2:58 PM UTC (25b7c05)">Diff</a>