### PR TITLE
Apply post-merge review suggestions from #196

### DIFF
--- a/extended-profile/index.html
+++ b/extended-profile/index.html
@@ -912,8 +912,8 @@
               <a>YAML representation graph</a>
               and the {{JsonLdOptions/processingMode}} option is not equal to `yaml-ld-extended`,
               the conversion result is the value of the target node,
-              as described in the
-              <a href="#aa-json-aliases">Basic profile alias handling</a>.
+              as described in
+              <a href="#aa-json-aliases">basic profile alias handling</a>.
             </p>
 
             <p id="cir-alias-cycles" data-tests="

--- a/index.html
+++ b/index.html
@@ -969,7 +969,7 @@ schema:hasPart:
       alias nodes MUST be resolved by value to their target nodes.
     </p>
 
-    <aside class="note" title="Anchors and aliases are YAML serialization features">
+    <aside class="note" title="Anchors and aliases are features of YAML serialization">
       <p>
         Converting a YAML-LD document with anchors or aliases to JSON-LD,
         and then serializing it back to YAML-LD, preserves the semantic data


### PR DESCRIPTION
## Summary

Applies the two `suggestion` review comments left by @TallTed on PR #196 after it merged:

- [Lowercase the link text and drop "the"](https://github.com/w3c/yaml-ld/pull/196#discussion_r3156027970) in `extended-profile/index.html` (`as described in the Basic profile alias handling` → `as described in basic profile alias handling`).
- [Rephrase the aside title](https://github.com/w3c/yaml-ld/pull/196#discussion_r3156035371) in `index.html` (`Anchors and aliases are YAML serialization features` → `Anchors and aliases are features of YAML serialization`).

@iherman's separate suggestion to move the new note after Example 5 is tracked in #197 and intentionally left out of scope here.

## Test plan

- [x] `make spec` exits 0 (only pre-existing `require is not defined` warning from `common/common.js`).
- [x] `make extended-profile` exits 0 (only pre-existing `testSuiteURI` ReSpec warning, same as PR #196).
- [x] Rendered output in `web/extended-profile/index.html` contains "basic profile alias handling" and no longer contains "Basic profile alias handling".
- [x] Rendered output in `web/index.html` contains "features of YAML serialization" and no longer contains "YAML serialization features".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/199.html" title="Last updated on May 1, 2026, 5:46 PM UTC (7a29347)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/199/a7733a0...7a29347.html" title="Last updated on May 1, 2026, 5:46 PM UTC (7a29347)">Diff</a>