### PR TITLE
Fix common.js to use document.respec.ready (CI broken by respec v37)

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -1,13 +1,11 @@
-/* globals require */
 /* JSON-LD Working Group common spec JavaScript */
 
 /*
 * Implement tabbed examples.
 */
-require(["core/pubsubhub"], (respecEvents) => {
+function postProcess() {
   "use strict";
 
-  respecEvents.sub('end-all', (documentElement) => {
     //
     // Playground
     //
@@ -74,8 +72,13 @@ require(["core/pubsubhub"], (respecEvents) => {
         .replace(/####([^#]*)####/g, '<span class="comment">$1</span>');
       pre.innerHTML = content;
     }
-  });
-});
+}
+
+if (document.respec) {
+  document.respec.ready.then(postProcess);
+} else {
+  document.addEventListener("DOMContentLoaded", postProcess);
+}
 
 function _esc(s) {
   return s.replace(/&/g,'&amp;')


### PR DESCRIPTION
## Summary

`common/common.js` opened with an AMD `require(["core/pubsubhub"], ...)` call to subscribe to ReSpec's `end-all` event, but the script is loaded as a plain `<script src="common/common.js" class="remove" defer>` from `index.html` and `extended-profile/index.html` — there is no RequireJS on the page, so `require` is undefined.

This always threw `ReferenceError: require is not defined`, but older respec/spec-prod treated it as a non-fatal warning. ReSpec v37 (now used by `w3c/spec-prod@v2`) logs it as `[ERROR]`; combined with spec-prod's `-e` flag, respec exits 1 and CI fails on every branch.

The fix replaces the AMD wrapper with `document.respec.ready.then(postProcess)` — the same hook the repo's published snapshots already use (e.g. `publication-snapshots/WD-yaml-ld-10-20260305/Overview.html:3726`).

This unblocks PR #199 and any future PR's CI.

## Test plan

- [x] Reproduced before the change: `respec --localhost --src index.html -e` exits **1** with `[ERROR] require is not defined` at `common/common.js:7`.
- [x] After the change: `respec --localhost --src index.html -e` exits **0** with no `[ERROR]` or `[FATAL]` lines (this is exactly what `w3c/spec-prod@v2` runs in CI).
- [x] Diff is minimal — only the AMD wrapper changed; the callback body is untouched.
- [ ] CI on this branch goes green.