### PR TITLE
Tighten Introduction section

### DIFF
--- a/examples/generated/intro.jsonld
+++ b/examples/generated/intro.jsonld
@@ -1,22 +1,19 @@
 {
-  "@context": [
-    "https://json-ld.org/contexts/dollar-convenience.jsonld",
-    {
-      "schema": "https://schema.org/",
-      "dbo": "http://dbpedia.org/ontology/",
-      "dbp": "http://dbpedia.org/property/",
-      "dbr": "http://dbpedia.org/resource/",
-      "xsd": "http://www.w3.org/2001/XMLSchema#",
-      "dbp:discovered": {
-        "@type": "xsd:date"
-      },
-      "dbp:star": {
-        "@type": "@id"
-      }
+  "@context": {
+    "schema": "https://schema.org/",
+    "dbo": "http://dbpedia.org/ontology/",
+    "dbp": "http://dbpedia.org/property/",
+    "dbr": "http://dbpedia.org/resource/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dbp:discovered": {
+      "@type": "xsd:date"
+    },
+    "dbp:star": {
+      "@type": "@id"
     }
-  ],
-  "$id": "dbr:Proxima_Centauri_b",
-  "$type": "dbo:Planet",
+  },
+  "@id": "dbr:Proxima_Centauri_b",
+  "@type": "dbo:Planet",
   "schema:description": "The closest known exoplanet to Earth, orbiting in Proxima Centauri's habitable zone.",
   "dbp:discovered": "2016-08-24",
   "dbp:star": "dbr:Proxima_Centauri"

--- a/examples/intro.yamlld
+++ b/examples/intro.yamlld
@@ -1,17 +1,16 @@
 "@context":
-  - https://json-ld.org/contexts/dollar-convenience.jsonld
-  - schema: https://schema.org/
-    dbo: http://dbpedia.org/ontology/
-    dbp: http://dbpedia.org/property/
-    dbr: http://dbpedia.org/resource/
-    xsd: http://www.w3.org/2001/XMLSchema#
-    dbp:discovered:
-      "@type": xsd:date
-    dbp:star:
-      "@type": "@id"
+  schema: https://schema.org/
+  dbo: http://dbpedia.org/ontology/
+  dbp: http://dbpedia.org/property/
+  dbr: http://dbpedia.org/resource/
+  xsd: http://www.w3.org/2001/XMLSchema#
+  dbp:discovered:
+    "@type": xsd:date
+  dbp:star:
+    "@type": "@id"
 
-$id: dbr:Proxima_Centauri_b
-$type: dbo:Planet
+"@id": dbr:Proxima_Centauri_b
+"@type": dbo:Planet
 schema:description: >-
   The closest known exoplanet to Earth,
   orbiting in Proxima Centauri's habitable zone.

--- a/examples/mermaid/context-anchors.mmd
+++ b/examples/mermaid/context-anchors.mmd
@@ -1,20 +1,20 @@
 graph LR
-  http___dbpedia_org_resource_Proxima_Centauri_b("Proxima Centauri b")
+  http___dbpedia_org_resource_Proxima_Centauri_b("dbpedia.org/resource/Proxima_Centauri_b")
   click http___dbpedia_org_resource_Proxima_Centauri_b "http://dbpedia.org/resource/Proxima_Centauri_b"
-  http___dbpedia_org_resource_European_Southern_Observatory("🔭 European Southern Observatory")
+  http___dbpedia_org_resource_European_Southern_Observatory("dbpedia.org/resource/European_Southern_Observatory")
   click http___dbpedia_org_resource_European_Southern_Observatory "http://dbpedia.org/resource/European_Southern_Observatory"
-  http___dbpedia_org_resource_Doppler_spectroscopy("ƒ Doppler spectroscopy")
+  http___dbpedia_org_resource_Doppler_spectroscopy("dbpedia.org/resource/Doppler_spectroscopy")
   click http___dbpedia_org_resource_Doppler_spectroscopy "http://dbpedia.org/resource/Doppler_spectroscopy"
-  http___dbpedia_org_resource_Proxima_Centauri("🔴 Proxima Centauri")
+  http___dbpedia_org_resource_Proxima_Centauri("dbpedia.org/resource/Proxima_Centauri")
   click http___dbpedia_org_resource_Proxima_Centauri "http://dbpedia.org/resource/Proxima_Centauri"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_b057205bcac1(["📍 discovery site"])--> http___dbpedia_org_resource_European_Southern_Observatory
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_b057205bcac1(["dbpedia.org/property/discoverySite"])--> http___dbpedia_org_resource_European_Southern_Observatory
   click Edge_b057205bcac1 "http://dbpedia.org/property/discoverySite"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d11d2061f7bd(["discovery method"])--> http___dbpedia_org_resource_Doppler_spectroscopy
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d11d2061f7bd(["dbpedia.org/property/discoveryMethod"])--> http___dbpedia_org_resource_Doppler_spectroscopy
   click Edge_d11d2061f7bd "http://dbpedia.org/property/discoveryMethod"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d03b11f4404f(["☉ star"])--> http___dbpedia_org_resource_Proxima_Centauri
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d03b11f4404f(["dbpedia.org/property/star"])--> http___dbpedia_org_resource_Proxima_Centauri
   click Edge_d03b11f4404f "http://dbpedia.org/property/star"
   classDef predicate fill:#1f2233,stroke:transparent,color:#f8fafc,stroke-width:0px;
   classDef hidden fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
   classDef nanopubdot fill:#0f172a,stroke:#0f172a,color:transparent,stroke-width:2px;
   classDef transparent fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
-  class Edge_b057205bcac1,Edge_d11d2061f7bd,Edge_d03b11f4404f predicate
+  

--- a/examples/mermaid/html-embed.mmd
+++ b/examples/mermaid/html-embed.mmd
@@ -1,15 +1,15 @@
 graph LR
-  http___dbpedia_org_resource_Proxima_Centauri_b("Proxima Centauri b")
+  http___dbpedia_org_resource_Proxima_Centauri_b("dbpedia.org/resource/Proxima_Centauri_b")
   click http___dbpedia_org_resource_Proxima_Centauri_b "http://dbpedia.org/resource/Proxima_Centauri_b"
-  http___dbpedia_org_ontology_Planet("🪐 planet")
+  http___dbpedia_org_ontology_Planet("dbpedia.org/ontology/Planet")
   click http___dbpedia_org_ontology_Planet "http://dbpedia.org/ontology/Planet"
   Literal_27f67571cab3[["📅 2016-08-24"]]
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["∈ type"])--> http___dbpedia_org_ontology_Planet
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["w3.org/1999/02/22-rdf-syntax-ns#type"])--> http___dbpedia_org_ontology_Planet
   click Edge_540e00cae247 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_a0efd4f3aa3e(["📅 discovered"])--> Literal_27f67571cab3
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_a0efd4f3aa3e(["dbpedia.org/property/discovered"])--> Literal_27f67571cab3
   click Edge_a0efd4f3aa3e "http://dbpedia.org/property/discovered"
   classDef predicate fill:#1f2233,stroke:transparent,color:#f8fafc,stroke-width:0px;
   classDef hidden fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
   classDef nanopubdot fill:#0f172a,stroke:#0f172a,color:transparent,stroke-width:2px;
   classDef transparent fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
-  class Edge_540e00cae247,Edge_a0efd4f3aa3e predicate
+  

--- a/examples/mermaid/intro.mmd
+++ b/examples/mermaid/intro.mmd
@@ -1,22 +1,22 @@
 graph LR
-  http___dbpedia_org_resource_Proxima_Centauri_b("Proxima Centauri b")
+  http___dbpedia_org_resource_Proxima_Centauri_b("dbpedia.org/resource/Proxima_Centauri_b")
   click http___dbpedia_org_resource_Proxima_Centauri_b "http://dbpedia.org/resource/Proxima_Centauri_b"
-  http___dbpedia_org_ontology_Planet("🪐 planet")
+  http___dbpedia_org_ontology_Planet("dbpedia.org/ontology/Planet")
   click http___dbpedia_org_ontology_Planet "http://dbpedia.org/ontology/Planet"
   Literal_27f67571cab3[["📅 2016-08-24"]]
   Literal_60f6527b948d[["The closest known exoplanet to Earth, orbiting in Proxima Centauri’s habitable zone."]]
-  http___dbpedia_org_resource_Proxima_Centauri("🔴 Proxima Centauri")
+  http___dbpedia_org_resource_Proxima_Centauri("dbpedia.org/resource/Proxima_Centauri")
   click http___dbpedia_org_resource_Proxima_Centauri "http://dbpedia.org/resource/Proxima_Centauri"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["∈ type"])--> http___dbpedia_org_ontology_Planet
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["w3.org/1999/02/22-rdf-syntax-ns#type"])--> http___dbpedia_org_ontology_Planet
   click Edge_540e00cae247 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_a0efd4f3aa3e(["📅 discovered"])--> Literal_27f67571cab3
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_a0efd4f3aa3e(["dbpedia.org/property/discovered"])--> Literal_27f67571cab3
   click Edge_a0efd4f3aa3e "http://dbpedia.org/property/discovered"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_29580035684f(["description"])--> Literal_60f6527b948d
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_29580035684f(["schema.org/description"])--> Literal_60f6527b948d
   click Edge_29580035684f "https://schema.org/description"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d03b11f4404f(["☉ star"])--> http___dbpedia_org_resource_Proxima_Centauri
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_d03b11f4404f(["dbpedia.org/property/star"])--> http___dbpedia_org_resource_Proxima_Centauri
   click Edge_d03b11f4404f "http://dbpedia.org/property/star"
   classDef predicate fill:#1f2233,stroke:transparent,color:#f8fafc,stroke-width:0px;
   classDef hidden fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
   classDef nanopubdot fill:#0f172a,stroke:#0f172a,color:transparent,stroke-width:2px;
   classDef transparent fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
-  class Edge_540e00cae247,Edge_a0efd4f3aa3e,Edge_29580035684f,Edge_d03b11f4404f predicate
+  

--- a/examples/mermaid/json-literal.mmd
+++ b/examples/mermaid/json-literal.mmd
@@ -1,11 +1,11 @@
 graph LR
-  http___dbpedia_org_resource_Proxima_Centauri_b("Proxima Centauri b")
+  http___dbpedia_org_resource_Proxima_Centauri_b("dbpedia.org/resource/Proxima_Centauri_b")
   click http___dbpedia_org_resource_Proxima_Centauri_b "http://dbpedia.org/resource/Proxima_Centauri_b"
   Literal_0ed26ad5b509[["{“eccentricity“:0.11,“equilibriumTemperature“:234,“orbitalPeriod“:11.186,“semiMajorAxis“:0.0485}"]]
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_8070d2b95411(["additionalProperty"])--> Literal_0ed26ad5b509
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_8070d2b95411(["schema.org/additionalProperty"])--> Literal_0ed26ad5b509
   click Edge_8070d2b95411 "https://schema.org/additionalProperty"
   classDef predicate fill:#1f2233,stroke:transparent,color:#f8fafc,stroke-width:0px;
   classDef hidden fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
   classDef nanopubdot fill:#0f172a,stroke:#0f172a,color:transparent,stroke-width:2px;
   classDef transparent fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
-  class Edge_8070d2b95411 predicate
+  

--- a/examples/mermaid/stream.mmd
+++ b/examples/mermaid/stream.mmd
@@ -1,18 +1,18 @@
 graph LR
-  http___dbpedia_org_resource_Proxima_Centauri_b("Proxima Centauri b")
+  http___dbpedia_org_resource_Proxima_Centauri_b("dbpedia.org/resource/Proxima_Centauri_b")
   click http___dbpedia_org_resource_Proxima_Centauri_b "http://dbpedia.org/resource/Proxima_Centauri_b"
-  http___dbpedia_org_ontology_Planet("🪐 planet")
+  http___dbpedia_org_ontology_Planet("dbpedia.org/ontology/Planet")
   click http___dbpedia_org_ontology_Planet "http://dbpedia.org/ontology/Planet"
-  http___dbpedia_org_resource_Proxima_Centauri("🔴 Proxima Centauri")
+  http___dbpedia_org_resource_Proxima_Centauri("dbpedia.org/resource/Proxima_Centauri")
   click http___dbpedia_org_resource_Proxima_Centauri "http://dbpedia.org/resource/Proxima_Centauri"
-  http___dbpedia_org_ontology_Star("⋆ star")
+  http___dbpedia_org_ontology_Star("dbpedia.org/ontology/Star")
   click http___dbpedia_org_ontology_Star "http://dbpedia.org/ontology/Star"
-  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["∈ type"])--> http___dbpedia_org_ontology_Planet
+  http___dbpedia_org_resource_Proxima_Centauri_b --- Edge_540e00cae247(["w3.org/1999/02/22-rdf-syntax-ns#type"])--> http___dbpedia_org_ontology_Planet
   click Edge_540e00cae247 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-  http___dbpedia_org_resource_Proxima_Centauri --- Edge_79508a7869da(["∈ type"])--> http___dbpedia_org_ontology_Star
+  http___dbpedia_org_resource_Proxima_Centauri --- Edge_79508a7869da(["w3.org/1999/02/22-rdf-syntax-ns#type"])--> http___dbpedia_org_ontology_Star
   click Edge_79508a7869da "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
   classDef predicate fill:#1f2233,stroke:transparent,color:#f8fafc,stroke-width:0px;
   classDef hidden fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
   classDef nanopubdot fill:#0f172a,stroke:#0f172a,color:transparent,stroke-width:2px;
   classDef transparent fill:transparent,stroke:transparent,color:transparent,stroke-width:0px;
-  class Edge_540e00cae247,Edge_79508a7869da predicate
+  

--- a/index.html
+++ b/index.html
@@ -372,48 +372,6 @@
     <h2>Introduction</h2>
 
     <p>
-      <strong>Objective</strong><br>
-      This document defines YAML-LD, a set of conventions built on top
-      of YAML, which outlines how to serialize Linked Data as YAML
-      based on JSON-LD syntax, semantics, and APIs. The emergence of
-      YAML as a more concise format for representing information
-      previously serialized as JSON, including Linked Data, has led to
-      the development of YAML-LD.
-    </p>
-
-    <p>
-      <strong>Methods</strong><br>
-      This document defines constraints on YAML so that any YAML-LD
-      document can be represented in JSON-LD. This is necessary
-      because YAML is more expressive than JSON, in terms of both
-      available data types and document structure. This document
-      also registers the <code>application/ld+yaml</code> media type.
-    </p>
-
-    <p>
-      <strong>Results</strong><br>
-      This document provides a clear description of how to serialize
-      Linked Data in YAML. It also describes the basic concepts and
-      core requirements for implementing YAML-LD, including a
-      comparison of JSON versus YAML, the supported YAML features,
-      and encoding considerations.
-    </p>
-
-    <p>
-      <strong>Limitations</strong><br>
-      The YAML feature set is richer than that of JSON, and a number of
-      YAML features are not supported in this specification. However,
-      ground is laid for future development of a version of YAML-LD
-      which will support those features — via the Extended YAML-LD
-      Profile.
-    </p>
-    <p>
-      <strong>Conclusions</strong><br>
-      YAML-LD offers an efficient way to encode Linked Data in a
-      variety of programming languages which can use YAML.
-    </p>
-
-    <p>
       <strong>An introductory YAML-LD example</strong> is presented below.
     </p>
 
@@ -430,13 +388,6 @@
                data-include-format="text"></pre>
         </div>
       </div>
-
-    <div class="ednote">
-      See YAML-LD description of this spec at
-      <a href="data/spec.yamlld" target="_blank">
-        <code>spec.yamlld</code>
-      </a>.
-    </div>
 
   <section class="informative">
     <h2>How to read this document</h2>

--- a/index.html
+++ b/index.html
@@ -372,6 +372,12 @@
     <h2>Introduction</h2>
 
     <p>
+      YAML-LD applies JSON-LD's data model and processing model to YAML
+      so that Linked Data can be written in a YAML syntax while remaining
+      representable as JSON-LD.
+    </p>
+
+    <p>
       <strong>An introductory YAML-LD example</strong> is presented below.
     </p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yaml-ld-spec"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = ["yaml-ld>=1.1.22", "PyLD<3.0.0", "iolanta>=2.1.41"]
+dependencies = ["yaml-ld>=1.1.22", "PyLD<3.0.0", "iolanta>=2.1.42"]
 
 [tool.setuptools]
 packages = []

--- a/scripts/generate-examples.sh
+++ b/scripts/generate-examples.sh
@@ -17,8 +17,8 @@ mkdir -p examples/generated
 IOLANTA=".venv/bin/iolanta"
 mkdir -p examples/mermaid
 
-PYTHONHASHSEED=0 "$IOLANTA" examples/intro.yamlld           --as mermaid 2>/dev/null > examples/mermaid/intro.mmd
-PYTHONHASHSEED=0 "$IOLANTA" examples/context-anchors.yamlld --as mermaid 2>/dev/null > examples/mermaid/context-anchors.mmd
-PYTHONHASHSEED=0 "$IOLANTA" examples/stream.yamlld          --as mermaid 2>/dev/null > examples/mermaid/stream.mmd
-PYTHONHASHSEED=0 "$IOLANTA" examples/json-literal.yamlld    --as mermaid 2>/dev/null > examples/mermaid/json-literal.mmd
-PYTHONHASHSEED=0 "$IOLANTA" examples/html-embed.html        --as mermaid 2>/dev/null > examples/mermaid/html-embed.mmd
+PYTHONHASHSEED=0 "$IOLANTA" examples/intro.yamlld           --as mermaid/rdf 2>/dev/null > examples/mermaid/intro.mmd
+PYTHONHASHSEED=0 "$IOLANTA" examples/context-anchors.yamlld --as mermaid/rdf 2>/dev/null > examples/mermaid/context-anchors.mmd
+PYTHONHASHSEED=0 "$IOLANTA" examples/stream.yamlld          --as mermaid/rdf 2>/dev/null > examples/mermaid/stream.mmd
+PYTHONHASHSEED=0 "$IOLANTA" examples/json-literal.yamlld    --as mermaid/rdf 2>/dev/null > examples/mermaid/json-literal.mmd
+PYTHONHASHSEED=0 "$IOLANTA" examples/html-embed.html        --as mermaid/rdf 2>/dev/null > examples/mermaid/html-embed.mmd


### PR DESCRIPTION
## Summary

- Remove redundant Objective–Conclusions summary paragraphs and `spec.yamlld` ednote from Introduction (Abstract and subsections already cover that ground)
- Remove dollar-convenience context from introductory example
- Regenerate `intro.jsonld` derived output

Stacked on #212 (`stricter-mermaid-visualizations`).

## Test plan

- [ ] `make spec` passes locally
- [ ] Introduction renders with example + diagram only
- [ ] CI on stacked PR passes


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/213.html" title="Last updated on Jul 8, 2026, 9:30 AM UTC (fb19bb8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/213/c384952...fb19bb8.html" title="Last updated on Jul 8, 2026, 9:30 AM UTC (fb19bb8)">Diff</a>