### PR TITLE
add intro explicitly refering to yaml processing steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,6 +901,17 @@
   <section id="core-requirements" class="normative">
     <h2>Core Requirements</h2>
 
+    <p>
+      [[[YAML]]] describes YAML processing in a number of steps, reproduced in <a href="#yaml-processing"></a>.
+      This processing transforms a stream of characters in the YAML syntax (on the right) to and from a so-called "native data structure" (on the left).
+      In JSON-LD, that data structure is the JSON-LD [=internal representation=].
+      This section describes the requirements imposed by YAML-LD the YAML processing steps.
+    </p>
+    <figure id="yaml-processing">
+      <img src="https://yaml.org/spec/1.2.2/img/overview2.svg" alt="YAML Processing Overview" />
+      <figcaption>YAML processing overview, from [[YAML]]</figcaption>
+    </figure>
+
     <section id="encoding">
     <h2>Encoding</h2>
 


### PR DESCRIPTION
This PR captures the essence of the improvements I said I wanted to propose on §4 Requirements.

It is a minimal change, but I think it is already useful as is.

We could go further by mentioning the different steps from Figure 1 in the remaining subsections. E.g. 4.1 Encoding
is about the 'Present' and 'Parse' steps. §4.2 Comments and §4.3 Anchors and Aliases directly follow from the overall processing: comments are not part of the intermediary structures (besides 'Presentation'), and anchors/aliases are "expanded" in the 'Representation' structure, so clearly they can not be leveraged by JSON-LD processing. etc...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/219.html" title="Last updated on Jul 9, 2026, 1:43 PM UTC (e15b3dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/219/c384952...e15b3dc.html" title="Last updated on Jul 9, 2026, 1:43 PM UTC (e15b3dc)">Diff</a>