### PR TITLE
[#218]: Fix YAML-LD document vs stream terminology

### DIFF
--- a/extended-profile/index.html
+++ b/extended-profile/index.html
@@ -1132,8 +1132,8 @@
           manifest.html#cr-utf8-1-positive,
           manifest.html#cr-utf8-2-negative">
               Although YAML supports several additional encodings,
-              YAML-LD documents in the <a>YAML-LD Basic Profile</a>
-              MUST NOT use encodings other than UTF-8.
+              YAML-LD streams in the <a>YAML-LD Basic Profile</a>
+              MUST be encoded in UTF-8.
             </p>
 
             <p>
@@ -1168,8 +1168,8 @@
           manifest.html#cr-utf8-1-positive,
           manifest.html#cr-utf8-2-negative">
               As with the <a>YAML-LD Basic profile</a>,
-              YAML-LD documents in the <a>YAML-LD extended profile</a>
-              MUST NOT use encodings other than UTF-8.
+              YAML-LD streams in the <a>YAML-LD extended profile</a>
+              MUST be encoded in UTF-8.
             </p>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -455,6 +455,8 @@
 
     <p>A <dfn>YAML-LD stream</dfn> is a <a data-cite="YAML#92-streams" data-no-xref="">YAML stream</a>
       of <a>YAML-LD documents</a>.
+      On disk or on the wire, YAML-LD is always exchanged as a <a>YAML-LD stream</a>
+      (one stream per file or HTTP body), containing one or more <a>YAML-LD documents</a>.
     </p>
     
     <p>A <dfn>YAML-LD document</dfn> is any <a>YAML document</a> from
@@ -875,7 +877,7 @@
     <p id="cr-utf8" data-tests="
       manifest.html#cr-utf8-1-positive,
       manifest.html#cr-utf8-2-negative">
-      A <a>YAML-LD document</a> MUST be encoded in UTF-8,
+      A <a>YAML-LD stream</a> MUST be encoded in UTF-8,
       to ensure interoperability with [[JSON]];
       otherwise, an
       <a data-link-for="YamlLdErrorCode">invalid-encoding</a>
@@ -886,7 +888,7 @@
     <section id="comments">
       <h2>Comments</h2>
       <p id="cr-comments" data-tests="manifest.html#cr-comments-1-positive">
-        Comments in <a>YAML-LD documents</a> are treated as white space.
+        Comments in <a>YAML-LD streams</a> are treated as white space.
       </p>
 
       <p>
@@ -1138,8 +1140,8 @@
       </p>
 
       <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
-        A conformant YAML-LD specification MUST also take this flag into account
-        when parsing a normal YAML-LD <a>stream</a>.
+        A conformant YAML-LD implementation MUST take this flag into account
+        while parsing a YAML-LD <a>stream</a>.
       </p>
 
       <ul>
@@ -1322,7 +1324,7 @@ enum YamlLdErrorCode {
           <dt><code>profile</code></dt>
           <dd>
             <p>A non-empty list of space-separated URIs identifying specific
-              constraints or conventions that apply to a <a>YAML-LD document</a> according to [[RFC6906]].
+              constraints or conventions that apply to a <a>YAML-LD stream</a> according to [[RFC6906]].
               A profile does not change the semantics of the resource representation
               when processed without profile knowledge, so that clients both with
               and without knowledge of a profiled resource can safely use the same
@@ -1339,10 +1341,10 @@ enum YamlLdErrorCode {
             </p>
             <dl>
               <dt><code>http://www.w3.org/ns/json-ld#extended</code></dt>
-              <dd>To request or specify <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form.
+              <dd>To request or specify the <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>.
                 <div class="ednote">
-                  This is a placeholder for specifying something like an
-                  <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form
+                  This is a placeholder for specifying something like the
+                  <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>
                   making use of YAML-specific features.
                 </div></dd>
             </dl>

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -339,7 +339,7 @@
                   <dt>ID</dt><dd>#cr-utf8-1-positive</dd></dt>
                   <dt>Type</dt><dd>jld:PositiveEvaluationTest,jld:ExpandTest</dd>
                   <dt>Name</dt><dd>UTF-8 BOM</dd></dt>
-                  <dt>Purpose</dt><dd>A YAML-LD document MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].</dd></dt>
+                  <dt>Purpose</dt><dd>A YAML-LD stream MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].</dd></dt>
                   <dt>Input</dt><dd><a href="cases/cr-utf8-1-positive-in.yamlld">cases/cr-utf8-1-positive-in.yamlld</a></dd></dt>
                   <dt>References</dt><dd>(<a href="../index.html#cr-utf8">1</a>) (<a href="../index.html#jp-utf8">2</a>) (<a href="../index.html#ep-utf8">3</a>)</dd></dt>
                   <dt>Requirement</dt><dd><strong>must</strong></dd>
@@ -359,7 +359,7 @@
                   <dt>ID</dt><dd>#cr-utf8-2-negative</dd></dt>
                   <dt>Type</dt><dd>jld:NegativeEvaluationTest,jld:ExpandTest</dd>
                   <dt>Name</dt><dd>UTF-16 BOM</dd></dt>
-                  <dt>Purpose</dt><dd>A YAML-LD document MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].</dd></dt>
+                  <dt>Purpose</dt><dd>A YAML-LD stream MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].</dd></dt>
                   <dt>Input</dt><dd><a href="cases/cr-utf8-2-negative-in.yamlld">cases/cr-utf8-2-negative-in.yamlld</a></dd></dt>
                   <dt>References</dt><dd>(<a href="../index.html#cr-utf8">1</a>) (<a href="../index.html#cir-stream">2</a>) (<a href="../index.html#cir-document">3</a>) (<a href="../index.html#cir-mapping">4</a>) (<a href="../index.html#jp-utf8">5</a>) (<a href="../index.html#ep-utf8">6</a>)</dd></dt>
                   <dt>Requirement</dt><dd><strong>must</strong></dd>

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -103,7 +103,7 @@
       "@id": "#cr-utf8-1-positive",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "UTF-8 BOM",
-      "purpose": "A YAML-LD document MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].",
+      "purpose": "A YAML-LD stream MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].",
       "req": "must",
       "input": "cases/cr-utf8-1-positive-in.yamlld",
       "expect": "cases/cr-utf8-1-positive-out.yamlld"
@@ -112,7 +112,7 @@
       "@id": "#cr-utf8-2-negative",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "UTF-16 BOM",
-      "purpose": "A YAML-LD document MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].",
+      "purpose": "A YAML-LD stream MUST be encoded in UTF-8, to ensure interoperability with [[JSON]].",
       "req": "must",
       "input": "cases/cr-utf8-2-negative-in.yamlld",
       "expectErrorCode": "invalid encoding"


### PR DESCRIPTION
## Summary
- Clarify that on-disk/on-wire YAML-LD is always a stream (one stream per file or HTTP body) containing one or more documents.
- Rephrase stream-level requirements (encoding, comments, `extractAllScripts`, IANA `profile`) to use YAML-LD stream; point the `#extended` profile at the YAML-LD Extended Profile.
- Align extended-profile UTF-8 requirements and UTF-8 test purposes with the same wording.

Closes #218

## Test plan
- [ ] `make spec` succeeds
- [ ] `make extended-profile` succeeds
- [ ] Spot-check `#encoding`, Terminology, Comments, Streams, and IANA `profile` in the rendered spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/221.html" title="Last updated on Jul 22, 2026, 6:11 PM UTC (d33fff4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/221/af4c9c8...d33fff4.html" title="Last updated on Jul 22, 2026, 6:11 PM UTC (d33fff4)">Diff</a>