### PR TITLE
Note YAML-LD agent use and cite YAML vs JSON size comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,39 +689,7 @@
       <p>[[YAML]] is a superset of [[JSON]], i.e., every valid JSON document is also a valid YAML document.
         YAML also offers a number of extra features, chief among which is improved
         human readability due to the minimized punctuation requirements.</p>
-
-      <p>
-        [[?eriksson-hallberg]] compared JSON documents vs YAML in size and found that,
-        depending on document structure, YAML can be more compact than pretty-printed JSON:
-      </p>
-      <table class="simple">
-        <thead>
-        <tr>
-          <th>Sample</th>
-          <th>vs<br/>pretty-printed JSON</th>
-          <th>vs<br/>minified (compact) JSON</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-          <th>Flat</th>
-          <td>≈26% smaller</td>
-          <td>≈1% smaller</td>
-        </tr>
-        <tr>
-          <th>Deeply nested</th>
-          <td>≈2% larger</td>
-          <td>≈10% larger</td>
-        </tr>
-        </tbody>
-      </table>
-
-      <p>Although YAML can be larger than equivalent JSON for some deeply nested documents,
-        for many flatter documents it is smaller than pretty-printed JSON while remaining human-readable.
-        That combination can reduce the amount of text that large language models and other software agents
-        must process, without requiring a separate minified encoding.</p>
-
-      <p>YAML is also more flexible than JSON, as illustrated by the comparison table below.</p>
+      <p>YAML is more flexible than JSON, as illustrated by the comparison table below.</p>
 
       <table class="simple">
         <thead>

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@
         human readability due to the minimized punctuation requirements.</p>
 
       <p>
-        [[eriksson-hallberg]] compared JSON documents vs YAML in size and found that,
+        [[?eriksson-hallberg]] compared JSON documents vs YAML in size and found that,
         depending on document structure, YAML can be more compact than pretty-printed JSON:
       </p>
       <table class="simple">

--- a/index.html
+++ b/index.html
@@ -143,6 +143,17 @@
           "Anatoly Scherbakov",
         ],
       },
+      "eriksson-hallberg": {
+        title: "Comparison between JSON and YAML for data serialization",
+        href: "https://www.csc.kth.se/utbildning/kth/kurser/DD143X/dkand11/Group2Mads/Rapport_Malin_Eriksson_Viktor_Hallberg.pdf",
+        publisher: "KTH Royal Institute of Technology",
+        date: "2011",
+        status: "Bachelor's thesis",
+        authors: [
+          "Malin Eriksson",
+          "Victor Hallberg",
+        ],
+      },
     },
 
     // Cross-reference definitions
@@ -374,7 +385,10 @@
     <p>
       YAML-LD applies JSON-LD's data model and processing model to YAML
       so that Linked Data can be written in a YAML syntax while remaining
-      representable as JSON-LD.
+      representable as JSON-LD.</p>
+
+    <p>It is intended for documents that are read and written by humans and by
+      software agents, including those based on Large Language Models.
     </p>
 
     <p>
@@ -672,9 +686,41 @@
     <section id="json-vs-yaml">
       <h3>JSON vs YAML comparison</h3>
 
-      <p>YAML is a superset of JSON, i.e., every valid JSON document is also a valid YAML document.
+      <p>[[YAML]] is a superset of [[JSON]], i.e., every valid JSON document is also a valid YAML document.
         YAML also offers a number of extra features, chief amongst which is improved human readability due to the ability to use minimal punctuation.</p>
-      <p>YAML is more flexible than JSON, as illustrated by the comparison table below.</p>
+
+      <p>
+        [[eriksson-hallberg]] compared JSON documents vs YAML in size and found that,
+        depending on document structure, YAML can be more compact than pretty-printed JSON:
+      </p>
+      <table class="simple">
+        <thead>
+        <tr>
+          <th>Sample</th>
+          <th>vs<br/>pretty-printed JSON</th>
+          <th>vs<br/>minified (compact) JSON</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th>Flat</th>
+          <td>≈26% smaller</td>
+          <td>≈1% smaller</td>
+        </tr>
+        <tr>
+          <th>Deeply nested</th>
+          <td>≈2% larger</td>
+          <td>≈10% larger</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <p>Although YAML can be larger than equivalent JSON for some deeply nested documents,
+        for many flatter documents it is smaller than pretty-printed JSON while remaining human-readable.
+        That combination can reduce the amount of text that large language models and other software agents
+        must process, without requiring a separate minified encoding.</p>
+
+      <p>YAML is also more flexible than JSON, as illustrated by the comparison table below.</p>
 
       <table class="simple">
         <thead>

--- a/index.html
+++ b/index.html
@@ -856,7 +856,9 @@
         That combination can reduce the amount of text that large language models and other software agents
         must process, without requiring a separate minified encoding.</p>
     <p>
-      The first goal of this specification is to allow a <a>JSON-LD document</a> to be
+    <section><h3>Goal of this specification</h3>
+    <p>
+The goal of this specification is to allow a <a>JSON-LD document</a> to be
       processed and serialized into YAML, and then back into JSON-LD, without
       losing any semantic information.</p>
 

--- a/index.html
+++ b/index.html
@@ -687,7 +687,8 @@
       <h3>JSON vs YAML comparison</h3>
 
       <p>[[YAML]] is a superset of [[JSON]], i.e., every valid JSON document is also a valid YAML document.
-        YAML also offers a number of extra features, chief amongst which is improved human readability due to the ability to use minimal punctuation.</p>
+        YAML also offers a number of extra features, chief among which is improved
+        human readability due to the minimized punctuation requirements.</p>
 
       <p>
         [[eriksson-hallberg]] compared JSON documents vs YAML in size and found that,

--- a/index.html
+++ b/index.html
@@ -878,6 +878,7 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
          data-content-type="application/ld+json"
          title="JSON-LD equivalent of the introductory example"></pre>
   </section>
+  </section>
 
   <section id="core-requirements" class="normative">
     <h2>Core Requirements</h2>

--- a/index.html
+++ b/index.html
@@ -850,6 +850,11 @@
     </div>
     </section>
 
+      <p>
+        [[?eriksson-hallberg]] showed that, although YAML can be larger than equivalent JSON for some deeply nested documents,
+        for many flatter documents it is smaller than pretty-printed JSON while remaining human-readable.
+        That combination can reduce the amount of text that large language models and other software agents
+        must process, without requiring a separate minified encoding.</p>
     <p>
       The first goal of this specification is to allow a <a>JSON-LD document</a> to be
       processed and serialized into YAML, and then back into JSON-LD, without


### PR DESCRIPTION
## Summary
- State in the Introduction that YAML-LD is intended for humans and software agents, including those based on large language models.
- In `#json-vs-yaml`, cite Eriksson & Hallberg (2011) with a small size-comparison table (flat vs deeply nested × pretty vs minified JSON).
- Note that compactness with human readability can reduce text processed by LLMs and other agents, without requiring a separate minified encoding.

## Test plan
- [ ] `make spec` succeeds
- [ ] Rendered `#json-vs-yaml` shows the new table and biblio link to `eriksson-hallberg`
- [ ] Introduction purpose sentence reads correctly in the rendered abstract/intro flow


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/222.html" title="Last updated on Jul 23, 2026, 10:23 AM UTC (99c108a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/222/b4d47fb...99c108a.html" title="Last updated on Jul 23, 2026, 10:23 AM UTC (99c108a)">Diff</a>