### PR TITLE
[#220]: Restructure Core Requirements around YAML processing models

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,6 +469,8 @@
 
     <p>A <dfn>YAML-LD stream</dfn> is a <a data-cite="YAML#92-streams" data-no-xref="">YAML stream</a>
       of <a>YAML-LD documents</a>.
+      On disk or on the wire, YAML-LD is always exchanged as a <a>YAML-LD stream</a>
+      (one stream per file or HTTP body), containing one or more <a>YAML-LD documents</a>.
     </p>
     
     <p>A <dfn>YAML-LD document</dfn> is any <a>YAML document</a> from
@@ -805,7 +807,7 @@
           <th>Documents per file</th>
           <td>1</td>
           <td>⩾ 1 via <a>YAML stream</a></td>
-          <td>⩾ 1 (depending on <code>extractAllScripts</code> flag, see <a href="#streams">Streams</a>)</td>
+          <td>⩾ 1 (depending on <code>extractAllScripts</code> flag, see <a href="#stream-processing">Stream Processing</a>)</td>
         </tr>
 
         <tr>
@@ -894,8 +896,8 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
     <p>
       This section describes the requirements imposed by YAML-LD on the YAML processing steps,
       in the load direction (right to left in <a href="#yaml-processing"></a>).
-      <a data-cite="YAML#dump">Dump</a> is the inverse; YAML-LD adds no dump-specific requirements
-      beyond emitting a YAML presentation of a JSON-compatible [=internal representation=].
+      <a data-cite="YAML#dump">Dump</a> proceeds in the opposite direction, producing
+      a conforming <a>YAML-LD stream</a> from a JSON-compatible [=internal representation=].
     </p>
 
     <section id="presentation">
@@ -949,8 +951,7 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
 
         <p>
           See
-          <a data-cite="RFC9512#section-3.4">Interoperability considerations of the
-          <code>+yaml</code> structured syntax suffix</a>
+          <a data-cite="RFC9512#section-3.4">YAML and JSON interoperability considerations</a>
           for more details.
         </p>
       </section>
@@ -987,28 +988,6 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
                  data-include-format="text"></pre>
           </div>
         </div>
-
-        <p class="informative">
-          [[JSON-LD11-API]] defines the
-          <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
-          multiple `&lt;script&gt;` tags with JSON-LD content in an HTML document.
-        </p>
-
-        <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
-          A conformant YAML-LD implementation MUST take this flag into account
-          while parsing a YAML-LD <a>stream</a>.
-        </p>
-
-        <ul>
-          <li>
-            If the flag is `true`, the <a>YAML stream</a> is considered an array,
-            and each document in it is an item in that array, even if there is
-            only one document in the stream.
-          </li>
-          <li>
-            If the flag is `false`, only the first document in the stream will be processed.
-          </li>
-        </ul>
 
         <p class="note" title="Interoperability considerations on YAML streams">
           For interoperability considerations on YAML streams,
@@ -1123,51 +1102,15 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
         <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
         error MUST be detected, and processing aborted.
       </p>
-    </section>
-
-    <section id="native-data-structure">
-      <h2>Native Data Structure</h2>
-
-      <p>
-        The native data structure produced by
-        <a data-cite="YAML#constructing-native-data-structures">Construct</a> in
-        <a href="#yaml-processing"></a>
-        is the JSON-LD [=internal representation=].
-      </p>
 
       <p id="aa-json-aliases" data-tests="
         manifest.html#aa-cycles-1-positive,
         manifest.html#aa-cycles-3-positive">
-        When constructing that [=internal representation=],
-        alias nodes MUST be resolved by value to their target nodes.
+        When composing the <a>representation graph</a>, each <a>alias node</a>
+        MUST resolve to the node identified by its target anchor.
+        When constructing the JSON-LD [=internal representation=], repeated references
+        to that node MUST be represented by value.
       </p>
-
-      <section id="mapping-key-types">
-        <h2>Mapping Key Types</h2>
-
-        <blockquote>
-          <p>
-            An object structure is represented as a pair of curly brackets
-            surrounding zero or more name/value pairs (or members).
-            A name is a string.
-          </p>
-          <footer>
-            — [[JSON]]
-            <a data-cite="JSON#section-4">§4 Objects</a>
-          </footer>
-        </blockquote>
-
-        <p id="aa-mapping-key-types" data-tests="
-          manifest.html#cir-mapping-key-1-negative,
-          manifest.html#cir-mapping-key-2-negative,
-          manifest.html#cir-mapping-key-3-negative,
-          manifest.html#cir-mapping-key-4-negative,
-          manifest.html#cir-mapping-key-5-negative,
-        ">
-          Consequently, mapping key type MUST be a <code>string</code>.
-          Otherwise, a processing error is raised.
-        </p>
-      </section>
 
       <section id="scalar-value-types">
         <h2>Scalar Value Types</h2>
@@ -1198,10 +1141,12 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
           manifest.html#core-yaml11-off,
           manifest.html#core-yaml11-yes-title,
           manifest.html#core-yaml11-yes-upper">
-          YAML-LD uses the <a data-cite="YAML#103-core-schema">YAML Core Schema</a> for scalar type resolution.
+          When composing a complete <a>representation graph</a>, YAML-LD uses the
+          <a data-cite="YAML#103-core-schema">YAML Core Schema</a> for scalar type resolution.
           Float values that cannot be represented in [[JSON]] — specifically
           infinity (<code>.inf</code>, <code>-.inf</code>, <code>+.inf</code>) and
-          not-a-number (<code>.nan</code>) — MUST cause a
+          not-a-number (<code>.nan</code>) — MUST cause construction of the
+          JSON-LD [=internal representation=] to raise a
           <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
           error.
         </p>
@@ -1286,6 +1231,70 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
             </tbody>
           </table>
         </aside>
+      </section>
+    </section>
+
+    <section id="native-data-structure">
+      <h2>Native Data Structure</h2>
+
+      <p>
+        The native data structure produced by
+        <a data-cite="YAML#constructing-native-data-structures">Construct</a> in
+        <a href="#yaml-processing"></a>
+        is the JSON-LD [=internal representation=].
+      </p>
+
+      <section id="stream-processing">
+        <h2>Stream Processing</h2>
+
+        <p class="informative">
+          [[JSON-LD11-API]] defines the
+          <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
+          multiple `&lt;script&gt;` tags with JSON-LD content in an HTML document.
+        </p>
+
+        <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
+          A conformant YAML-LD implementation MUST apply this flag when constructing
+          the JSON-LD [=internal representation=] from a YAML-LD <a>stream</a>.
+        </p>
+
+        <ul>
+          <li>
+            If the flag is `true`, the internal representation MUST be an array
+            containing the constructed value of each document in the stream,
+            even if the stream contains only one document.
+          </li>
+          <li>
+            If the flag is `false`, only the first document in the stream MUST be constructed.
+          </li>
+        </ul>
+      </section>
+
+      <section id="mapping-key-types">
+        <h2>Mapping Key Types</h2>
+
+        <blockquote>
+          <p>
+            An object structure is represented as a pair of curly brackets
+            surrounding zero or more name/value pairs (or members).
+            A name is a string.
+          </p>
+          <footer>
+            — [[JSON]]
+            <a data-cite="JSON#section-4">§4 Objects</a>
+          </footer>
+        </blockquote>
+
+        <p id="aa-mapping-key-types" data-tests="
+          manifest.html#cir-mapping-key-1-negative,
+          manifest.html#cir-mapping-key-2-negative,
+          manifest.html#cir-mapping-key-3-negative,
+          manifest.html#cir-mapping-key-4-negative,
+          manifest.html#cir-mapping-key-5-negative,
+        ">
+          Consequently, mapping key type MUST be a <code>string</code>.
+          Otherwise, a processing error is raised.
+        </p>
       </section>
 
       <section id="json-literals" class="informative">
@@ -1423,7 +1432,7 @@ enum YamlLdErrorCode {
     </p>
 
     <p data-tests="manifest.html#html-and-yaml-streams">
-      If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag. See <a href="#streams">Streams</a> for details.
+      If the YAML-LD <code>&lt;script></code> tag contains a <a>YAML Stream</a> with multiple <a>YAML documents</a>, each of these documents MUST be treated as if it was included in a separate <code>&lt;script></code> tag. See <a href="#stream-processing">Stream Processing</a> for details.
     </p>
   </section>
 
@@ -1451,7 +1460,7 @@ enum YamlLdErrorCode {
           <dt><code>profile</code></dt>
           <dd>
             <p>A non-empty list of space-separated URIs identifying specific
-              constraints or conventions that apply to a <a>YAML-LD document</a> according to [[RFC6906]].
+              constraints or conventions that apply to a <a>YAML-LD stream</a> according to [[RFC6906]].
               A profile does not change the semantics of the resource representation
               when processed without profile knowledge, so that clients both with
               and without knowledge of a profiled resource can safely use the same
@@ -1468,10 +1477,10 @@ enum YamlLdErrorCode {
             </p>
             <dl>
               <dt><code>http://www.w3.org/ns/json-ld#extended</code></dt>
-              <dd>To request or specify <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form.
+              <dd>To request or specify the <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>.
                 <div class="ednote">
-                  This is a placeholder for specifying something like an
-                  <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form
+                  This is a placeholder for specifying something like the
+                  <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>
                   making use of YAML-specific features.
                 </div></dd>
             </dl>

--- a/index.html
+++ b/index.html
@@ -1291,7 +1291,7 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
           manifest.html#cir-mapping-key-4-negative,
           manifest.html#cir-mapping-key-5-negative,
         ">
-          Consequently, mapping key type MUST be a <code>string</code>.
+          Consequently, all mapping keys in YAML-LD MUST be <code>string</code>s.
           Otherwise, a processing error is raised.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -469,8 +469,6 @@
 
     <p>A <dfn>YAML-LD stream</dfn> is a <a data-cite="YAML#92-streams" data-no-xref="">YAML stream</a>
       of <a>YAML-LD documents</a>.
-      On disk or on the wire, YAML-LD is always exchanged as a <a>YAML-LD stream</a>
-      (one stream per file or HTTP body), containing one or more <a>YAML-LD documents</a>.
     </p>
     
     <p>A <dfn>YAML-LD document</dfn> is any <a>YAML document</a> from
@@ -807,7 +805,7 @@
           <th>Documents per file</th>
           <td>1</td>
           <td>⩾ 1 via <a>YAML stream</a></td>
-          <td>⩾ 1 (depending on <code>extractAllScripts</code> flag, see <a href="#streams">Stream handling</a>)</td>
+          <td>⩾ 1 (depending on <code>extractAllScripts</code> flag, see <a href="#streams">Streams</a>)</td>
         </tr>
 
         <tr>
@@ -828,7 +826,7 @@
           <th>Cycles</th>
           <td>❌</td>
           <td><a data-cite="YAML#321-representation-graph">✅</a></td>
-          <td><a href="#anchors-aliases">❌ Not permitted</a></td>
+          <td><a href="#aa-cycles">❌ Not permitted</a></td>
         </tr>
 
         <tr>
@@ -887,347 +885,453 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
       [[[YAML]]] describes YAML processing in a number of steps, reproduced in <a href="#yaml-processing"></a>.
       This processing transforms a stream of characters in the YAML syntax (on the right) to and from a so-called "native data structure" (on the left).
       In JSON-LD, that data structure is the JSON-LD [=internal representation=].
-      This section describes the requirements imposed by YAML-LD on the YAML processing steps.
     </p>
     <figure id="yaml-processing">
       <img src="images/yaml-processing.svg" alt="YAML Processing Overview" />
       <figcaption>YAML processing overview, from [[YAML]]</figcaption>
     </figure>
 
-    <section id="encoding">
-    <h2>Encoding</h2>
-
-    <p id="cr-utf8" data-tests="
-      manifest.html#cr-utf8-1-positive,
-      manifest.html#cr-utf8-2-negative">
-      A <a>YAML-LD stream</a> MUST be encoded in UTF-8,
-      to ensure interoperability with [[JSON]];
-      otherwise, an
-      <a data-link-for="YamlLdErrorCode">invalid-encoding</a>
-      MUST be detected, and processing aborted.
+    <p>
+      This section describes the requirements imposed by YAML-LD on the YAML processing steps,
+      in the load direction (right to left in <a href="#yaml-processing"></a>).
+      <a data-cite="YAML#dump">Dump</a> is the inverse; YAML-LD adds no dump-specific requirements
+      beyond emitting a YAML presentation of a JSON-compatible [=internal representation=].
     </p>
-    </section>
 
-    <section id="comments">
-      <h2>Comments</h2>
-      <p id="cr-comments" data-tests="manifest.html#cr-comments-1-positive">
-        Comments in <a>YAML-LD streams</a> are treated as white space.
-      </p>
+    <section id="presentation">
+      <h2>Presentation</h2>
 
       <p>
-        See Interoperability considerations of "+yaml" structured syntax suffix
-        for more details.
-      </p>
-    </section>
-
-    <section id="anchors-aliases">
-    <h2>Anchors and Aliases</h2>
-    <p class="note">
-      In this specification, <em>anchor</em> means YAML's
-      <a data-cite="YAML#node-anchors">node anchor</a> mechanism
-      (with <a data-cite="YAML#alias-nodes">alias nodes</a>, using <code>&amp;</code> and <code>*</code>
-      in the serialization) to reuse the same logical node by reference in the serialized graph.
-      It is not related to <a data-cite="HTML#the-a-element">HTML hyperlinks</a>
-      or <a data-cite="URI#section-3.5">URL fragment identifiers</a>.
-      See [[YAML]]
-      <a data-cite="YAML#3222-anchors-and-aliases">§3.2.2.2 Anchors and Aliases</a> and
-      <a data-cite="YAML#node-anchors">§6.9.2 Node Anchors</a>.
-    </p>
-    <p id="aa-information" data-tests="manifest.html#aa-information-1-positive">
-      Since <a>anchor names</a> are a serialization detail, such anchors
-      MUST NOT be used to convey relevant information,
-      MAY be altered when processing the document,
-      and MAY be dropped during YAML-LD processing.
-    </p>
-
-    <p id="aa-cycles" data-tests="
-      manifest.html#aa-cycles-1-positive,
-      manifest.html#aa-cycles-2-negative,
-      manifest.html#aa-cycles-3-positive">
-      A <a>YAML-LD document</a> MAY contain <a>anchored nodes</a> and <a>alias nodes</a>,
-      but its <a>representation graph</a> MUST NOT contain cycles;
-      otherwise, a
-      <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
-      error MUST be detected, and processing aborted.
-    </p>
-
-    <p>
-      When interpreting the document as JSON-LD,
-      alias nodes MUST be resolved by value to their target nodes.
-    </p>
-
-    <p>
-      Anchors are particularly useful within a <code>@context</code> block.
-      When several terms share the same term definition — for example, all
-      IRI-valued properties — the shared definition can be anchored once and
-      aliased for each term, avoiding repetition.
-      The following example anchors the IRI coercion definition as
-      <code>&amp;iri</code> and reuses it for three properties:
-    </p>
-
-    <div class="example-with-diagram">
-      <pre class="example yaml"
-           id="example-with-anchors"
-           data-include="examples/context-anchors.yamlld"
-           data-include-format="text"
-           data-content-type="application/ld+yaml"
-           title="YAML-LD context with anchors"></pre>
-      <div class="mermaid-diagram">
-        <pre class="mermaid-source"
-             data-include="examples/mermaid/context-anchors.mmd"
-             data-include-format="text"></pre>
-      </div>
-    </div>
-
-    <p>
-      Once all anchors and aliases have been resolved, the equivalent JSON-LD is:
-    </p>
-
-    <pre class="example json"
-         data-include="examples/generated/context-anchors.jsonld"
-         data-include-format="text"
-         data-result-for="YAML-LD context with anchors"
-         data-content-type="application/ld+json"
-         title="JSON-LD resulting from YAML-LD context with anchors"></pre>
-
-    <aside class="note" title="Anchors and aliases are features of YAML serialization">
-      <p>
-        Converting a YAML-LD document with anchors or aliases to JSON-LD,
-        and then serializing it back to YAML-LD, preserves the semantic data
-        but is not expected to recreate the original anchors, aliases,
-        or anchor names.
-      </p>
-    </aside>
-    </section>
-
-    <section id="mapping-key-types">
-      <h2>Mapping Key Types</h2>
-
-      <p id="aa-mapping-key-types" data-tests="
-        manifest.html#cir-mapping-key-1-negative,
-        manifest.html#cir-mapping-key-2-negative,
-        manifest.html#cir-mapping-key-3-negative,
-        manifest.html#cir-mapping-key-4-negative,
-        manifest.html#cir-mapping-key-5-negative,
-      ">
-        Mapping key type MUST be a <code>string</code>. Otherwise, a processing error is raised.
-      </p>
-    </section>
-
-    <section id="scalar-value-types">
-      <h2>Scalar Value Types</h2>
-
-      <p id="yaml-core-schema-requirement" data-tests="
-        manifest.html#core-bool-true,
-        manifest.html#core-bool-false,
-        manifest.html#core-bool-true-title,
-        manifest.html#core-bool-false-upper,
-        manifest.html#core-null-null,
-        manifest.html#core-null-tilde,
-        manifest.html#core-null-upper,
-        manifest.html#core-int-decimal,
-        manifest.html#core-int-octal,
-        manifest.html#core-int-hex,
-        manifest.html#core-float-basic,
-        manifest.html#core-float-scientific,
-        manifest.html#core-date-ymd,
-        manifest.html#core-float-inf-negative,
-        manifest.html#core-float-neg-inf-negative,
-        manifest.html#core-float-plus-inf-negative,
-        manifest.html#core-float-nan-negative,
-        manifest.html#core-float-nan-mixed-negative,
-        manifest.html#core-float-nan-upper-negative,
-        manifest.html#core-yaml11-yes,
-        manifest.html#core-yaml11-no,
-        manifest.html#core-yaml11-on,
-        manifest.html#core-yaml11-off,
-        manifest.html#core-yaml11-yes-title,
-        manifest.html#core-yaml11-yes-upper">
-        YAML-LD uses the <a data-cite="YAML#103-core-schema">YAML Core Schema</a> for scalar type resolution.
-        Float values that cannot be represented in [[JSON]] — specifically
-        infinity (<code>.inf</code>, <code>-.inf</code>, <code>+.inf</code>) and
-        not-a-number (<code>.nan</code>) — MUST cause a
-        <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
-        error.
-      </p>
-      <p>
-        The <a data-cite="YAML#103-core-schema">YAML Core Schema</a> does not define a timestamp type;
-        scalars such as <code>2018-04-01</code> resolve to plain strings.
-        However, many YAML libraries implement YAML 1.1 timestamp resolution by default
-        and will silently convert such scalars to native date or datetime objects.
-        YAML-LD processors MUST NOT perform such conversion and MUST treat these values as strings.
+        Presentation is the YAML character stream in <a href="#yaml-processing"></a>.
       </p>
 
-      <p id="node-tags">
-        YAML-LD does not assign additional JSON-LD meaning to <a>node tags</a>
-        beyond the scalar type resolution defined by the
-        <a data-cite="YAML#103-core-schema">YAML Core Schema</a>.
-      </p>
+      <section id="encoding">
+        <h2>Encoding</h2>
 
-      <aside class="note" title="Core Schema type resolution">
-        <p>
-          The following table summarizes scalar type resolution per the
-          <a data-cite="YAML#103-core-schema">YAML Core Schema</a> and YAML-LD behaviour:
+        <blockquote>
+          <p>
+            JSON text exchanged between systems that are not part of a closed
+            ecosystem MUST be encoded using UTF-8.
+          </p>
+          <footer>
+            — [[JSON]]
+            <a data-cite="JSON#section-8.1">§8.1 Character Encoding</a>
+          </footer>
+        </blockquote>
+
+        <p id="cr-utf8" data-tests="
+          manifest.html#cr-utf8-1-positive,
+          manifest.html#cr-utf8-2-negative">
+          A <a>YAML-LD stream</a> MUST be encoded in UTF-8;
+          otherwise, an
+          <a data-link-for="YamlLdErrorCode">invalid-encoding</a>
+          error MUST be detected, and processing aborted.
         </p>
-        <table>
-          <thead>
-            <tr>
-              <th>Pattern</th>
-              <th>Resolved tag</th>
-              <th>YAML-LD</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>null | Null | NULL | ~</code></td>
-              <td><code>tag:yaml.org,2002:null</code></td>
-              <td>JSON <code>null</code></td>
-            </tr>
-            <tr>
-              <td><em>(empty)</em></td>
-              <td><code>tag:yaml.org,2002:null</code></td>
-              <td>JSON <code>null</code></td>
-            </tr>
-            <tr>
-              <td><code>true | True | TRUE | false | False | FALSE</code></td>
-              <td><code>tag:yaml.org,2002:bool</code></td>
-              <td>JSON <code>true</code> / <code>false</code></td>
-            </tr>
-            <tr>
-              <td><code>[-+]?[0-9]+</code></td>
-              <td><code>tag:yaml.org,2002:int</code> (base 10)</td>
-              <td>JSON number</td>
-            </tr>
-            <tr>
-              <td><code>0o[0-7]+</code></td>
-              <td><code>tag:yaml.org,2002:int</code> (base 8)</td>
-              <td>JSON number</td>
-            </tr>
-            <tr>
-              <td><code>0x[0-9a-fA-F]+</code></td>
-              <td><code>tag:yaml.org,2002:int</code> (base 16)</td>
-              <td>JSON number</td>
-            </tr>
-            <tr>
-              <td><code>[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?</code></td>
-              <td><code>tag:yaml.org,2002:float</code> (number)</td>
-              <td>JSON number</td>
-            </tr>
-            <tr>
-              <td><code>[-+]?(\.inf|\.Inf|\.INF)</code></td>
-              <td><code>tag:yaml.org,2002:float</code> (infinity)</td>
-              <td>raises <code>loading-document-failed</code></td>
-            </tr>
-            <tr>
-              <td><code>\.nan|\.NaN|\.NAN</code></td>
-              <td><code>tag:yaml.org,2002:float</code> (NaN)</td>
-              <td>raises <code>loading-document-failed</code></td>
-            </tr>
-            <tr>
-              <td><em>(any other)</em></td>
-              <td><code>tag:yaml.org,2002:str</code></td>
-              <td>JSON string</td>
-            </tr>
-          </tbody>
-        </table>
-      </aside>
+      </section>
+
+      <section id="comments">
+        <h2>Comments</h2>
+
+        <blockquote>
+          <p>
+            Comments are a presentation detail and must not have any effect on the
+            serialization tree or representation graph.
+          </p>
+          <footer>
+            — [[YAML]]
+            <a data-cite="YAML#3233-comments">§3.2.3.3 Comments</a>
+          </footer>
+        </blockquote>
+
+        <p id="cr-comments" data-tests="manifest.html#cr-comments-1-positive">
+          Comments in <a>YAML-LD streams</a> are treated as white space.
+        </p>
+
+        <p>
+          See
+          <a data-cite="RFC9512#section-3.4">Interoperability considerations of the
+          <code>+yaml</code> structured syntax suffix</a>
+          for more details.
+        </p>
+      </section>
+
+      <section id="streams">
+        <h2>Streams</h2>
+
+        <blockquote>
+          <p>
+            YAML allows several serialization trees to be contained in the same YAML
+            presentation stream, as a series of documents separated by markers.
+          </p>
+          <footer>
+            — [[YAML]]
+            <a data-cite="YAML#323-presentation-stream">§3.2.3 Presentation Stream</a>
+          </footer>
+        </blockquote>
+
+        <p>
+          A <a>YAML-LD stream</a> MAY contain more than one
+          <a>YAML-LD document</a>, as shown below.
+        </p>
+
+        <div class="example-with-diagram">
+          <pre class="example yaml"
+               data-include="examples/stream.yamlld"
+               data-include-format="text"
+               data-result-for="YAML-LD with multiple documents"
+               data-content-type="application/ld+json"
+               title="YAML-LD with several documents in one file"></pre>
+          <div class="mermaid-diagram">
+            <pre class="mermaid-source"
+                 data-include="examples/mermaid/stream.mmd"
+                 data-include-format="text"></pre>
+          </div>
+        </div>
+
+        <p class="informative">
+          [[JSON-LD11-API]] defines the
+          <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
+          multiple `&lt;script&gt;` tags with JSON-LD content in an HTML document.
+        </p>
+
+        <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
+          A conformant YAML-LD implementation MUST take this flag into account
+          while parsing a YAML-LD <a>stream</a>.
+        </p>
+
+        <ul>
+          <li>
+            If the flag is `true`, the <a>YAML stream</a> is considered an array,
+            and each document in it is an item in that array, even if there is
+            only one document in the stream;
+          </li>
+          <li>
+            If the flag is `false`, only the first document in the stream will be processed.
+          </li>
+        </ul>
+
+        <p class="note" title="Interoperability considerations on YAML streams">
+          For interoperability considerations on YAML streams,
+          see <a data-cite="RFC9512#section-3.2">the relevant section in YAML Media Type</a>.
+        </p>
+      </section>
     </section>
 
-    <section id="streams">
-      <h2>Streams</h2>
+    <section id="serialization">
+      <h2>Serialization</h2>
 
       <p>
-        Every YAML-LD file is a <a>YAML-LD stream</a>
-        and might contain multiple <a>YAML-LD documents</a>,
-        as shown in the example below.
+        Serialization is the ordered tree produced by
+        <a data-cite="YAML#parsing-the-presentation-stream">Parse</a>
+        (and consumed by
+        <a data-cite="YAML#presenting-the-serialization-tree">Present</a>)
+        in <a href="#yaml-processing"></a>.
       </p>
 
-      <div class="example-with-diagram">
-        <pre class="example yaml"
-             data-include="examples/stream.yamlld"
+      <section id="anchors-aliases">
+        <h2>Anchors and Aliases</h2>
+
+        <blockquote>
+          <p>
+            Anchor names are a serialization detail and are discarded once
+            composing is completed.
+          </p>
+          <footer>
+            — [[YAML]]
+            <a data-cite="YAML#3222-anchors-and-aliases">§3.2.2.2 Anchors and Aliases</a>
+          </footer>
+        </blockquote>
+
+        <p class="note">
+          In this specification, <em>anchor</em> means YAML's
+          <a data-cite="YAML#node-anchors">node anchor</a> mechanism
+          (with <a data-cite="YAML#alias-nodes">alias nodes</a>, using <code>&amp;</code> and <code>*</code>
+          in the serialization) to reuse the same logical node by reference in the serialized graph.
+          It is not related to <a data-cite="HTML#the-a-element">HTML hyperlinks</a>
+          or <a data-cite="URI#section-3.5">URL fragment identifiers</a>.
+          See [[YAML]]
+          <a data-cite="YAML#node-anchors">§6.9.2 Node Anchors</a>.
+        </p>
+        <p id="aa-information" data-tests="manifest.html#aa-information-1-positive">
+          Consequently, <a>anchor names</a>
+          MUST NOT be used to convey relevant information,
+          MAY be altered when processing the document,
+          and MAY be dropped during YAML-LD processing.
+        </p>
+
+        <p>
+          Anchors are particularly useful within a <code>@context</code> block.
+          When several terms share the same term definition — for example, all
+          IRI-valued properties — the shared definition can be anchored once and
+          aliased for each term, avoiding repetition.
+          The following example anchors the IRI coercion definition as
+          <code>&amp;iri</code> and reuses it for three properties:
+        </p>
+
+        <div class="example-with-diagram">
+          <pre class="example yaml"
+               id="example-with-anchors"
+               data-include="examples/context-anchors.yamlld"
+               data-include-format="text"
+               data-content-type="application/ld+yaml"
+               title="YAML-LD context with anchors"></pre>
+          <div class="mermaid-diagram">
+            <pre class="mermaid-source"
+                 data-include="examples/mermaid/context-anchors.mmd"
+                 data-include-format="text"></pre>
+          </div>
+        </div>
+
+        <p>
+          Once all anchors and aliases have been resolved, the equivalent JSON-LD is:
+        </p>
+
+        <pre class="example json"
+             data-include="examples/generated/context-anchors.jsonld"
              data-include-format="text"
-             data-result-for="YAML-LD with multiple documents"
+             data-result-for="YAML-LD context with anchors"
              data-content-type="application/ld+json"
-             title="YAML-LD with several documents in one file"></pre>
-        <div class="mermaid-diagram">
-          <pre class="mermaid-source"
-               data-include="examples/mermaid/stream.mmd"
-               data-include-format="text"></pre>
-        </div>
-      </div>
+             title="JSON-LD resulting from YAML-LD context with anchors"></pre>
 
-      <p class="informative">
-        [[JSON-LD11-API]] defines the
-        <a data-cite="JSON-LD11-API#dom-jsonldoptions-extractallscripts">`extractAllScripts`</a> flag, which allows to parse
-        multiple `&lt;script&gt;` tags with JSON-LD content in an HTML document.
+        <aside class="note" title="Anchors and aliases are features of YAML serialization">
+          <p>
+            Converting a YAML-LD document with anchors or aliases to JSON-LD,
+            and then serializing it back to YAML-LD, preserves the semantic data
+            but is not expected to recreate the original anchors, aliases,
+            or anchor names.
+          </p>
+        </aside>
+      </section>
+    </section>
+
+    <section id="representation">
+      <h2>Representation</h2>
+
+      <p>
+        Representation is the YAML <a>representation graph</a> produced by
+        <a data-cite="YAML#composing-the-representation-graph">Compose</a>
+        in <a href="#yaml-processing"></a>.
       </p>
 
-      <p data-tests="manifest.html#two-documents-from-stream,manifest.html#one-document-from-stream">
-        A conformant YAML-LD implementation MUST take this flag into account
-        while parsing a YAML-LD <a>stream</a>.
-      </p>
-
-      <ul>
-        <li>
-          If the flag is `true`, the <a>YAML stream</a> is considered an array,
-          and each document in it is an item in that array, even if there is
-          only one document in the stream;
-        </li>
-        <li>
-          If the flag is `false`, only the first document in the stream will be processed.
-        </li>
-      </ul>
-
-      <p class="note" title="Interoperability considerations on YAML streams">
-        For interoperability considerations on YAML streams,
-        see <a data-cite="RFC9512#section-3.2">the relevant section in YAML Media Type</a>.
+      <p id="aa-cycles" data-tests="
+        manifest.html#aa-cycles-1-positive,
+        manifest.html#aa-cycles-2-negative">
+        A <a>YAML-LD document</a> MAY contain <a>anchored nodes</a> and <a>alias nodes</a>
+        in its serialization,
+        but its <a>representation graph</a> MUST NOT contain cycles;
+        otherwise, a
+        <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
+        error MUST be detected, and processing aborted.
       </p>
     </section>
 
-    <section id="json-literals" class="informative">
-      <h2>JSON literals</h2>
+    <section id="native-data-structure">
+      <h2>Native Data Structure</h2>
 
       <p>
-        The <code>@json</code> keyword from JSON-LD 1.1 defines a <a data-cite="JSON-LD11#dfn-json-literal">JSON literal</a> as a <a>value object</a> with
-        <code>@type</code> <code>@json</code> and <code>@value</code> containing JSON data. A processor treats such a value as a JSON literal, rather than
-        interpreting it further as JSON-LD. Consider the following example.
+        The native data structure produced by
+        <a data-cite="YAML#constructing-native-data-structures">Construct</a> in
+        <a href="#yaml-processing"></a>
+        is the JSON-LD [=internal representation=].
       </p>
 
-      <div class="example-with-diagram">
-        <pre class="example yaml"
-             data-include="examples/json-literal.yamlld"
-             data-include-format="text"
-             data-content-type="application/ld+yaml"
-             title="JSON literal with orbital parameters for Proxima Centauri b"></pre>
-        <div class="mermaid-diagram">
-          <pre class="mermaid-source"
-               data-include="examples/mermaid/json-literal.mmd"
-               data-include-format="text"></pre>
+      <p id="aa-json-aliases" data-tests="
+        manifest.html#aa-cycles-1-positive,
+        manifest.html#aa-cycles-3-positive">
+        When constructing that [=internal representation=],
+        alias nodes MUST be resolved by value to their target nodes.
+      </p>
+
+      <section id="mapping-key-types">
+        <h2>Mapping Key Types</h2>
+
+        <blockquote>
+          <p>
+            An object structure is represented as a pair of curly brackets
+            surrounding zero or more name/value pairs (or members).
+            A name is a string.
+          </p>
+          <footer>
+            — [[JSON]]
+            <a data-cite="JSON#section-4">§4 Objects</a>
+          </footer>
+        </blockquote>
+
+        <p id="aa-mapping-key-types" data-tests="
+          manifest.html#cir-mapping-key-1-negative,
+          manifest.html#cir-mapping-key-2-negative,
+          manifest.html#cir-mapping-key-3-negative,
+          manifest.html#cir-mapping-key-4-negative,
+          manifest.html#cir-mapping-key-5-negative,
+        ">
+          Consequently, mapping key type MUST be a <code>string</code>.
+          Otherwise, a processing error is raised.
+        </p>
+      </section>
+
+      <section id="scalar-value-types">
+        <h2>Scalar Value Types</h2>
+
+        <p id="yaml-core-schema-requirement" data-tests="
+          manifest.html#core-bool-true,
+          manifest.html#core-bool-false,
+          manifest.html#core-bool-true-title,
+          manifest.html#core-bool-false-upper,
+          manifest.html#core-null-null,
+          manifest.html#core-null-tilde,
+          manifest.html#core-null-upper,
+          manifest.html#core-int-decimal,
+          manifest.html#core-int-octal,
+          manifest.html#core-int-hex,
+          manifest.html#core-float-basic,
+          manifest.html#core-float-scientific,
+          manifest.html#core-date-ymd,
+          manifest.html#core-float-inf-negative,
+          manifest.html#core-float-neg-inf-negative,
+          manifest.html#core-float-plus-inf-negative,
+          manifest.html#core-float-nan-negative,
+          manifest.html#core-float-nan-mixed-negative,
+          manifest.html#core-float-nan-upper-negative,
+          manifest.html#core-yaml11-yes,
+          manifest.html#core-yaml11-no,
+          manifest.html#core-yaml11-on,
+          manifest.html#core-yaml11-off,
+          manifest.html#core-yaml11-yes-title,
+          manifest.html#core-yaml11-yes-upper">
+          YAML-LD uses the <a data-cite="YAML#103-core-schema">YAML Core Schema</a> for scalar type resolution.
+          Float values that cannot be represented in [[JSON]] — specifically
+          infinity (<code>.inf</code>, <code>-.inf</code>, <code>+.inf</code>) and
+          not-a-number (<code>.nan</code>) — MUST cause a
+          <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
+          error.
+        </p>
+        <p>
+          The <a data-cite="YAML#103-core-schema">YAML Core Schema</a> does not define a timestamp type;
+          scalars such as <code>2018-04-01</code> resolve to plain strings.
+          However, many YAML libraries implement YAML 1.1 timestamp resolution by default
+          and will silently convert such scalars to native date or datetime objects.
+          YAML-LD processors MUST NOT perform such conversion and MUST treat these values as strings.
+        </p>
+
+        <p id="node-tags">
+          YAML-LD does not assign additional JSON-LD meaning to <a>node tags</a>
+          beyond the scalar type resolution defined by the
+          <a data-cite="YAML#103-core-schema">YAML Core Schema</a>.
+        </p>
+
+        <aside class="note" title="Core Schema type resolution">
+          <p>
+            The following table summarizes scalar type resolution per the
+            <a data-cite="YAML#103-core-schema">YAML Core Schema</a> and YAML-LD behaviour:
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Pattern</th>
+                <th>Resolved tag</th>
+                <th>YAML-LD</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>null | Null | NULL | ~</code></td>
+                <td><code>tag:yaml.org,2002:null</code></td>
+                <td>JSON <code>null</code></td>
+              </tr>
+              <tr>
+                <td><em>(empty)</em></td>
+                <td><code>tag:yaml.org,2002:null</code></td>
+                <td>JSON <code>null</code></td>
+              </tr>
+              <tr>
+                <td><code>true | True | TRUE | false | False | FALSE</code></td>
+                <td><code>tag:yaml.org,2002:bool</code></td>
+                <td>JSON <code>true</code> / <code>false</code></td>
+              </tr>
+              <tr>
+                <td><code>[-+]?[0-9]+</code></td>
+                <td><code>tag:yaml.org,2002:int</code> (base 10)</td>
+                <td>JSON number</td>
+              </tr>
+              <tr>
+                <td><code>0o[0-7]+</code></td>
+                <td><code>tag:yaml.org,2002:int</code> (base 8)</td>
+                <td>JSON number</td>
+              </tr>
+              <tr>
+                <td><code>0x[0-9a-fA-F]+</code></td>
+                <td><code>tag:yaml.org,2002:int</code> (base 16)</td>
+                <td>JSON number</td>
+              </tr>
+              <tr>
+                <td><code>[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?</code></td>
+                <td><code>tag:yaml.org,2002:float</code> (number)</td>
+                <td>JSON number</td>
+              </tr>
+              <tr>
+                <td><code>[-+]?(\.inf|\.Inf|\.INF)</code></td>
+                <td><code>tag:yaml.org,2002:float</code> (infinity)</td>
+                <td>raises <code>loading-document-failed</code></td>
+              </tr>
+              <tr>
+                <td><code>\.nan|\.NaN|\.NAN</code></td>
+                <td><code>tag:yaml.org,2002:float</code> (NaN)</td>
+                <td>raises <code>loading-document-failed</code></td>
+              </tr>
+              <tr>
+                <td><em>(any other)</em></td>
+                <td><code>tag:yaml.org,2002:str</code></td>
+                <td>JSON string</td>
+              </tr>
+            </tbody>
+          </table>
+        </aside>
+      </section>
+
+      <section id="json-literals" class="informative">
+        <h2>JSON literals</h2>
+
+        <p>
+          The <code>@json</code> keyword from JSON-LD 1.1 defines a <a data-cite="JSON-LD11#dfn-json-literal">JSON literal</a> as a <a>value object</a> with
+          <code>@type</code> <code>@json</code> and <code>@value</code> containing JSON data. A processor treats such a value as a JSON literal, rather than
+          interpreting it further as JSON-LD. Consider the following example.
+        </p>
+
+        <div class="example-with-diagram">
+          <pre class="example yaml"
+               data-include="examples/json-literal.yamlld"
+               data-include-format="text"
+               data-content-type="application/ld+yaml"
+               title="JSON literal with orbital parameters for Proxima Centauri b"></pre>
+          <div class="mermaid-diagram">
+            <pre class="mermaid-source"
+                 data-include="examples/mermaid/json-literal.mmd"
+                 data-include-format="text"></pre>
+          </div>
         </div>
-      </div>
 
-      <p>
-        Consider the expanded form.
-      </p>
+        <p>
+          Consider the expanded form.
+        </p>
 
-      <pre class="example json"
-           data-include="examples/generated/json-literal-expanded.jsonld"
-           data-include-format="text"
-           data-content-type="application/ld+json"
-           title="Expanded JSON literal with orbital parameters for Proxima Centauri b"></pre>
+        <pre class="example json"
+             data-include="examples/generated/json-literal-expanded.jsonld"
+             data-include-format="text"
+             data-content-type="application/ld+json"
+             title="Expanded JSON literal with orbital parameters for Proxima Centauri b"></pre>
 
-      <p>
-        Although the keyword is named <code>@json</code>, it does not require the
-        value of <code>@value</code> to be written using JSON syntax in YAML-LD. As this example shows, the metadata
-        value object is preserved during expansion in its JSON-LD form, — as this keyword mandates.
-      </p>
+        <p>
+          Although the keyword is named <code>@json</code>, it does not require the
+          value of <code>@value</code> to be written using JSON syntax in YAML-LD. As this example shows, the metadata
+          value object is preserved during expansion in its JSON-LD form, — as this keyword mandates.
+        </p>
 
-      <p>
-        When it is converted to RDF, the JSON literal's lexical form is
-        <a data-cite="RFC8259#section-2">JSON text</a> reconstructed from the
-        <a data-cite="JSON-LD11-API#dfn-internal-representation">internal representation</a>.
-      </p>
-
+        <p>
+          When it is converted to RDF, the JSON literal's lexical form is
+          <a data-cite="RFC8259#section-2">JSON text</a> reconstructed from the
+          <a data-cite="JSON-LD11-API#dfn-internal-representation">internal representation</a>.
+        </p>
+      </section>
     </section>
   </section>
 
@@ -1347,7 +1451,7 @@ enum YamlLdErrorCode {
           <dt><code>profile</code></dt>
           <dd>
             <p>A non-empty list of space-separated URIs identifying specific
-              constraints or conventions that apply to a <a>YAML-LD stream</a> according to [[RFC6906]].
+              constraints or conventions that apply to a <a>YAML-LD document</a> according to [[RFC6906]].
               A profile does not change the semantics of the resource representation
               when processed without profile knowledge, so that clients both with
               and without knowledge of a profiled resource can safely use the same
@@ -1364,10 +1468,10 @@ enum YamlLdErrorCode {
             </p>
             <dl>
               <dt><code>http://www.w3.org/ns/json-ld#extended</code></dt>
-              <dd>To request or specify the <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>.
+              <dd>To request or specify <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form.
                 <div class="ednote">
-                  This is a placeholder for specifying something like the
-                  <a data-cite="yaml-ld-extended-profile#">YAML-LD Extended Profile</a>
+                  This is a placeholder for specifying something like an
+                  <a data-cite="yaml-ld-extended-profile#">extended</a> <a>YAML-LD document</a> form
                   making use of YAML-specific features.
                 </div></dd>
             </dl>

--- a/index.html
+++ b/index.html
@@ -1108,8 +1108,8 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
         manifest.html#aa-cycles-3-positive">
         When composing the <a>representation graph</a>, each <a>alias node</a>
         MUST resolve to the node identified by its target anchor.
-        When constructing the JSON-LD [=internal representation=], repeated references
-        to that node MUST be represented by value.
+        When constructing the JSON-LD [=internal representation=], each reference
+        to that node MUST be treated as a copy of the node.
       </p>
 
       <section id="scalar-value-types">

--- a/index.html
+++ b/index.html
@@ -1003,7 +1003,7 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
           <li>
             If the flag is `true`, the <a>YAML stream</a> is considered an array,
             and each document in it is an item in that array, even if there is
-            only one document in the stream;
+            only one document in the stream.
           </li>
           <li>
             If the flag is `false`, only the first document in the stream will be processed.

--- a/index.html
+++ b/index.html
@@ -1292,7 +1292,7 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
           manifest.html#cir-mapping-key-5-negative,
         ">
           Consequently, all mapping keys in YAML-LD MUST be <code>string</code>s.
-          Otherwise, a processing error is raised.
+          Otherwise, a `mapping-key-error` error is raised.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1145,10 +1145,9 @@ The goal of this specification is to allow a <a>JSON-LD document</a> to be
           <a data-cite="YAML#103-core-schema">YAML Core Schema</a> for scalar type resolution.
           Float values that cannot be represented in [[JSON]] — specifically
           infinity (<code>.inf</code>, <code>-.inf</code>, <code>+.inf</code>) and
-          not-a-number (<code>.nan</code>) — MUST cause construction of the
-          JSON-LD [=internal representation=] to raise a
+          not-a-number (<code>.nan</code>) — MUST cause a
           <a data-cite="JSON-LD11-API#dom-jsonlderrorcode-loading-document-failed">loading-document-failed</a>
-          error.
+          error to be raised when constructing the JSON-LD [=internal representation=].
         </p>
         <p>
           The <a data-cite="YAML#103-core-schema">YAML Core Schema</a> does not define a timestamp type;

--- a/tests/manifest.html
+++ b/tests/manifest.html
@@ -461,7 +461,7 @@
                   <dt>Name</dt><dd>Alias node resolution</dd></dt>
                   <dt>Purpose</dt><dd>Alias nodes MUST be resolved by value to their target nodes.</dd></dt>
                   <dt>Input</dt><dd><a href="cases/aa-cycles-3-positive-in.yamlld">cases/aa-cycles-3-positive-in.yamlld</a></dd></dt>
-                  <dt>References</dt><dd>(<a href="../index.html#aa-cycles">1</a>) (<a href="../index.html#cir-alias-cycles">2</a>)</dd></dt>
+                  <dt>References</dt><dd>(<a href="../index.html#aa-json-aliases">1</a>) (<a href="../index.html#cir-alias-cycles">2</a>)</dd></dt>
                   <dt>Requirement</dt><dd><strong>must</strong></dd>
                   
                   


### PR DESCRIPTION
## Summary
- Vendor the YAML processing overview diagram and reference it from Core Requirements
- Restructure Core Requirements so top-level subsections follow the diagram’s information models (Presentation, Serialization, Representation, Native data structure)
- Add founding blockquotes from [[YAML]] / [[JSON]] where the YAML-LD rules are direct consequences; keep stable fragment IDs for tests and comparison-table links

## Test plan
- [ ] `make spec` succeeds
- [ ] Compare against base PR #221 for stream/document terminology consistency
- [ ] Confirm `#encoding`, `#comments`, `#streams`, `#anchors-aliases`, `#aa-cycles`, `#aa-json-aliases`, `#mapping-key-types`, `#scalar-value-types` still resolve
- [ ] Spot-check founding quotes and “Consequently…” MUST/MAY wording

Depends on #221 (this PR’s base).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/pull/224.html" title="Last updated on Jul 23, 2026, 10:33 AM UTC (07e6c78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/yaml-ld/224/8e4b455...07e6c78.html" title="Last updated on Jul 23, 2026, 10:33 AM UTC (07e6c78)">Diff</a>